### PR TITLE
Rebase-style conflict resolution during pull command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM python:$PYTHON_VERSION
 RUN pip install ipdb
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y vim
+ENV EDITOR=vim
+
 ADD README.md LICENSE MANIFEST.in requirements.txt setup.py /app/
 ADD jira_cli /app/jira_cli
 RUN pip install -e .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,6 @@ services:
       context: .
     volumes:
       - ./:/app
-      - ./config:/root/.config/jira-cli
+      - ./config:/root/.config/jiracli
       - /app/.git
       - /app/jira_cli.egg-info

--- a/jira_cli/__init__.py
+++ b/jira_cli/__init__.py
@@ -2,7 +2,7 @@
 # jira
 #
 
-__title__ = 'jira'
+__title__ = 'jiracli'
 __version__ = '0.0.1'
 __build__ = 0x000001
 __author__ = 'Matt Black'

--- a/jira_cli/config.py
+++ b/jira_cli/config.py
@@ -18,7 +18,7 @@ logger = logging.getLogger('jira')
 class AppConfig(DataclassSerializer):
     username: str = field(default=None)
     password: str = field(default=None)
-    hostname: str = field(default='jira.service.anz')
+    hostname: str = field(default='jira.atlassian.com')
     last_updated: str = field(default=None)
     projects: set = field(default_factory=set)
 

--- a/jira_cli/config.py
+++ b/jira_cli/config.py
@@ -7,6 +7,7 @@ import sys
 import click
 import requests
 
+from jira_cli import __title__
 from jira_cli.main import Jira
 from jira_cli.models import DataclassSerializer
 
@@ -23,7 +24,7 @@ class AppConfig(DataclassSerializer):
     projects: set = field(default_factory=set)
 
     def write_to_disk(self):
-        config_filepath = os.path.join(click.get_app_dir('jira-cli'), 'app.json')
+        config_filepath = os.path.join(click.get_app_dir(__title__), 'app.json')
         with open(config_filepath, 'w') as f:
             json.dump(self.serialize(), f)
 
@@ -36,7 +37,7 @@ def load_config(projects: set=None, prompt_for_creds: bool=False):
         projects:          List of Jira project keys
         prompt_for_creds:  Force a re-prompt for Jira credentials
     '''
-    config_filepath = os.path.join(click.get_app_dir('jira-cli'), 'app.json')
+    config_filepath = os.path.join(click.get_app_dir(__title__), 'app.json')
 
     config = None
 

--- a/jira_cli/entrypoint.py
+++ b/jira_cli/entrypoint.py
@@ -63,15 +63,19 @@ def cli_show(key):
 @cli.command(name='pull')
 @click.option('--projects', help='Jira project keys')
 @click.option('--login', is_flag=True, help='Reset the current login credentials')
+@click.option('--reset-hard', is_flag=True, help='Force reload of all issues. This will destroy any local changes!')
 @click.pass_context
-def cli_pull(ctx, projects: list=None, login: bool=False):
+def cli_pull(ctx, projects: list=None, login: bool=False, reset_hard: bool=False):
     '''Fetch and cache all JIRA issues'''
     if projects:
         projects = set(projects.split(','))
 
+    if reset_hard:
+        click.confirm('Warning! This will destroy any local changes. Continue?', abort=True)
+
     jira = Jira()
     jira.config = load_config(projects, prompt_for_creds=login)
-    pull_issues(jira, verbose=ctx.obj.verbose)
+    pull_issues(jira, force=reset_hard, verbose=ctx.obj.verbose)
 
 
 @cli.group(name='stats', invoke_without_command=True)

--- a/jira_cli/main.py
+++ b/jira_cli/main.py
@@ -14,7 +14,6 @@ from jira_cli.sync import pull_issues
 logger = logging.getLogger('jira')
 
 
-
 class Jira(collections.abc.MutableMapping):
     _jira = None
     _df = None

--- a/jira_cli/models.py
+++ b/jira_cli/models.py
@@ -1,12 +1,15 @@
+import dataclasses
 from dataclasses import dataclass, field
 import datetime
 import enum
 import textwrap
+from typing import Tuple
 
+import arrow
 import dictdiffer
 from tabulate import tabulate
 
-from jira_cli.utils import DataclassSerializer
+from jira_cli.utils import DataclassSerializer, friendly_title
 
 
 class IssueStatus(enum.Enum):
@@ -149,10 +152,7 @@ class Issue(DataclassSerializer):
             Returns:
                 tuple:      Pretty field title, formatted value
             '''
-            try:
-                title = issue_fields[field_name].metadata['friendly']
-            except KeyError:
-                title = field_name.replace('_', ' ').title()
+            title = friendly_title(field_name)
 
             value = getattr(self, field_name)
 

--- a/jira_cli/models.py
+++ b/jira_cli/models.py
@@ -37,19 +37,19 @@ class IssueStatus(enum.Enum):
 @dataclass
 class Issue(DataclassSerializer):
     assignee: str
-    created: datetime.datetime
-    creator: str
+    created: datetime.datetime = field(metadata={'readonly': True})
+    creator: str = field(metadata={'readonly': True})
     description: str
     fixVersions: set = field(metadata={'friendly': 'Fix Version'})
     issuetype: str = field(metadata={'friendly': 'Type'})
-    key: str
+    key: str = field(metadata={'readonly': True})
     labels: set
     priority: str
     project: str
     reporter: str
     status: IssueStatus
     summary: str
-    updated: datetime.datetime
+    updated: datetime.datetime = field(metadata={'readonly': True})
     estimate: int = field(default=None)
     epic_ref: str = field(default=None)
     epic_name: str = field(default=None, metadata={'friendly': 'Epic Short Name'})

--- a/jira_cli/sync.py
+++ b/jira_cli/sync.py
@@ -43,8 +43,10 @@ def pull_issues(jira: 'Jira', force: bool=False, verbose: bool=False):
         last_updated = '2010-01-01 00:00'
         logger.info('Querying for all Jira issues')
     else:
-        # load existing issue data from cache
-        jira.load_issues()
+        if not jira:
+            # load existing issue data from cache
+            jira.load_issues()
+
         last_updated = jira.config.last_updated
         logger.info('Querying for Jira issues since %s', last_updated)
 

--- a/jira_cli/sync.py
+++ b/jira_cli/sync.py
@@ -220,12 +220,16 @@ def _build_update(base_issue: Issue, updated_issue: Issue) -> IssueUpdate:
                 ret[i] = item
         return tuple(ret)
 
+    # fields to ignore during dictdiffer.diff
+    readonly_fields = [f.name for f in dataclasses.fields(Issue) if f.metadata.get('readonly')]
+    ignore_fields = set(['diff_to_original'] + readonly_fields)
+
     # generate two diffs to original Issue
     diff_original_to_base: set = set(make_hashable(list(dictdiffer.diff(
-        base_issue.original, base_issue_dict, ignore=set(['diff_to_original'])
+        base_issue.original, base_issue_dict, ignore=ignore_fields
     ))))
     diff_original_to_updated: set = set(make_hashable(list(dictdiffer.diff(
-        base_issue.original, updated_issue_dict, ignore=set(['diff_to_original'])
+        base_issue.original, updated_issue_dict, ignore=ignore_fields
     ))))
 
     # create mapping of modified field_name to a count

--- a/jira_cli/sync.py
+++ b/jira_cli/sync.py
@@ -1,11 +1,17 @@
+import copy
+import dataclasses
+from dataclasses import dataclass, field
 import datetime
 import logging
 
+import click
+import dictdiffer
 import pandas as pd
 from tabulate import tabulate
 from tqdm import tqdm
 
 from jira_cli.models import Issue
+from jira_cli.utils import DeserializeError, friendly_title
 
 
 CUSTOM_FIELD_EPIC_LINK = 'customfield_14182'
@@ -16,15 +22,18 @@ CUSTOM_FIELD_ESTIMATE = 'customfield_10002'
 logger = logging.getLogger('jira')
 
 
+class Conflict(Exception):
+    pass
+
+
 def pull_issues(jira: 'Jira', force: bool=False, verbose: bool=False):
     '''
     Pull changed issues from upstream Jira API
 
     Params:
-        jira:       main.Jira object
-        force:      Force reload of *all* issues, not just changed since `last_updated` value
-        verbose:    Verbose print all issues as they're pulled from the API (otherwise show
-                    progress bar)
+        jira:     Dependency-injected main.Jira object
+        force:    Force reload of *all* issues, not just changed since `last_updated` value
+        verbose:  Verbose print all issues as they're pulled from the API (default is progress bar)
     '''
     if not jira.config.projects:
         raise Exception('No projects configured, cannot continue')
@@ -47,7 +56,7 @@ def pull_issues(jira: 'Jira', force: bool=False, verbose: bool=False):
 
     pbar = None
 
-    def _run(jql, pbar=None):
+    def _run(jql: str, pbar=None) -> int:
         page = 0
         total = 0
 
@@ -59,9 +68,20 @@ def pull_issues(jira: 'Jira', force: bool=False, verbose: bool=False):
             page += 1
             total += len(issues)
 
-            # add/update all issues into jira
-            for issue in issues:
-                jira[issue.key] = _raw_issue_to_object(issue)
+            for api_issue in issues:
+                # convert from Jira object into Issue dataclass
+                issue = _raw_issue_to_object(api_issue)
+
+                try:
+                    # determine if local changes have been made
+                    if jira[api_issue.key].diff_to_original:
+                        # when pulling, the remote Issue is considered the base
+                        issue = check_resolve_conflicts(issue, jira[api_issue.key])
+                except KeyError:
+                    pass
+
+                # insert issue into Jira dict
+                jira[api_issue.key] = issue
 
             if pbar:
                 # update progress
@@ -77,12 +97,17 @@ def pull_issues(jira: 'Jira', force: bool=False, verbose: bool=False):
 
         return total
 
-    if verbose:
-        total = _run(jql)
-    else:
-        # show progress bar
-        with tqdm(total=head.total, unit=' issues') as pbar:
-            total = _run(jql, pbar)
+    try:
+        if verbose:
+            total = _run(jql)
+        else:
+            # show progress bar
+            with tqdm(total=head.total, unit=' issues') as pbar:
+                total = _run(jql, pbar)
+
+    except ConflictResolutionFailed as e:
+        logger.critical('Failed resolving conflict on %s during pull!', e)
+        return
 
     logger.info('Retrieved %s issues', total)
 
@@ -121,3 +146,238 @@ def _raw_issue_to_object(issue: dict) -> Issue:
         'summary': issue.fields.summary,
         'updated': issue.fields.updated,
     })
+
+
+@dataclass
+class IssueUpdate:
+    '''
+    A class representing an update to an Issue (or a new Issue)
+    '''
+    merged_issue: Issue
+    modified: set = field(default_factory=set)
+    conflicts: dict = field(default_factory=dict)
+
+
+def check_resolve_conflicts(base_issue: Issue, updated_issue: Issue) -> Issue:
+    '''
+    Check for and resolve conflicts on a single Issue
+
+    Params:
+        base_issue:     Base Issue to which we are comparing (has an .original property)
+        updated_issue:  Incoming updated Issue
+    Returns:
+        Resolved issue
+    '''
+    # construct an object representing changes/conflicts
+    update_object = _build_update(base_issue, updated_issue)
+
+    if not update_object.conflicts:
+        return update_object.merged_issue
+
+    return manual_conflict_resolution(update_object)
+
+
+def _build_update(base_issue: Issue, updated_issue: Issue) -> IssueUpdate:
+    '''
+    Generate an object representing an Issue update
+
+    There are three versions of the Issue at update time:
+
+      original:  The original Issue before any local modifications
+      base:      A modified Issue, to which the updated Issue is compared
+      updated:   Incoming modified Issue
+
+    The updated and base Issues are compared to the original Issue and are merged into the final Issue.
+    A conflict occurs when competing changes have been made on both the base and the updated Issue to
+    the same field.
+
+         Updated --- Merged
+         /          /
+      Origin --- Base
+
+    https://en.wikipedia.org/wiki/Merge_(version_control)#Three-way_merge
+
+    Params:
+        base_issue:     Base Issue to which we are comparing (has an .original property)
+        updated_issue:  Incoming updated Issue
+    Returns:
+        A dict object including the issue, a set of modified fields, and any conflicts
+    '''
+    # serialize both Issue objects to dict
+    base_issue_dict: dict = base_issue.serialize()
+    updated_issue_dict: dict = updated_issue.serialize()
+
+    def make_hashable(lst):
+        '''
+        Recursively convert lists and sets to be hashable tuples
+        '''
+        # clone `lst` arg to list type
+        ret = list(range(len(lst)))
+        for i, item in enumerate(lst):
+            if isinstance(item, (list, set, tuple)):
+                ret[i] = make_hashable(item)
+            else:
+                ret[i] = item
+        return tuple(ret)
+
+    # generate two diffs to original Issue
+    diff_original_to_base: set = set(make_hashable(list(dictdiffer.diff(
+        base_issue.original, base_issue_dict, ignore=set(['diff_to_original'])
+    ))))
+    diff_original_to_updated: set = set(make_hashable(list(dictdiffer.diff(
+        base_issue.original, updated_issue_dict, ignore=set(['diff_to_original'])
+    ))))
+
+    # create mapping of modified field_name to a count
+    grouped_modified = {}
+
+    # union base and updated changes to make complete set
+    for _, field_name, value in diff_original_to_updated | diff_original_to_base:
+        if not value:
+            return
+        if field_name not in grouped_modified:
+            grouped_modified[field_name] = 0
+        grouped_modified[field_name] += 1
+
+    # modifications with a count above 1 were made on both base and updated
+    conflict_fields: dict = {
+        field_name: {
+            'original': base_issue.original[field_name],
+            'updated': updated_issue_dict[field_name],
+            'base': base_issue_dict[field_name],
+        }
+        for field_name, count in grouped_modified.items() if count > 1
+    }
+
+    # make a copy of the base Issue
+    merged_issue = copy.deepcopy(base_issue)
+
+    # merge in modified fields from the updated Issue
+    for _, field_name, _ in diff_original_to_updated:
+        if grouped_modified[field_name] == 1:
+            setattr(merged_issue, field_name, getattr(updated_issue, field_name))
+
+    # mark conflicted fields
+    for field_name in grouped_modified:
+        if grouped_modified[field_name] > 1:
+            setattr(merged_issue, field_name, Conflict())
+
+    # return object modelling this update
+    return IssueUpdate(
+        merged_issue=merged_issue,
+        modified=grouped_modified.keys(),
+        conflicts=conflict_fields,
+    )
+
+
+class ConflictResolutionFailed(Exception):
+    pass
+
+class EditorFieldParseFailed(ValueError):
+    pass
+
+
+def manual_conflict_resolution(update_object: IssueUpdate) -> Issue:
+    '''
+    Manually resolve conflicts with $EDITOR
+
+    Params:
+        update_object:  Instance of IssueUpdate returned from _build_update
+    '''
+    # render issue to string, including conflict blocks
+    editor_conflict_text = update_object.merged_issue.__str__(update_object.conflicts)
+
+    retries = 1
+    while retries <= 3:
+        try:
+            # display interactively in $EDITOR
+            editor_result_raw = click.edit(
+                '\n'.join([
+                    '# Conflict(s) on Issue {}'.format(update_object.merged_issue.key), '',
+                    editor_conflict_text
+                ])
+            )
+
+            # error handling
+            # - no changes in click.edit returns None
+            # - empty string means abort
+            # - any <<< >>> are bad news
+            if not editor_result_raw:
+                raise EditorFieldParseFailed
+            for line in editor_result_raw:
+                if line.startswith(('<<', '>>', '==')):
+                    raise EditorFieldParseFailed
+
+            # parse the editor output into a new Issue
+            resolved_issue = parse_editor_result(update_object, editor_result_raw)
+            break
+
+        except (EditorFieldParseFailed, DeserializeError):
+            logger.error(
+                'Failed parsing the return from manual conflict resolution! Retry %s/3', retries
+            )
+        finally:
+            retries += 1
+    else:
+        # only reached if retries are exceeded
+        raise ConflictResolutionFailed(update_object.merged_issue.key)
+
+    return resolved_issue
+
+
+def parse_editor_result(update_object: IssueUpdate, editor_result_raw: str) -> Issue:
+    '''
+    Parse the string returned from the conflict editor
+
+    Params:
+        update_object:      Instance of IssueUpdate returned from _build_update
+        editor_result_raw:  Raw text returned by user from `click.edit` during interactive
+                            conflict resolution
+    Returns:
+        Edited Issue object
+    '''
+    # dict of Issue dataclass fields
+    issue_fields = {f.name:f for f in dataclasses.fields(Issue)}
+
+    # create dict to lookup a dataclass field by its pretty formatted name
+    issue_fields_by_friendly = {
+        friendly_title(f.name):f for f in dataclasses.fields(Issue)
+    }
+
+    editor_result = {}
+
+    # Process the raw input into a dict. Only conflicted fields are extracted as entries in the
+    # dict, and the value is a list of lines from the raw input
+    for line in editor_result_raw.splitlines():
+        if not line or line.startswith('#') or line.startswith('-'*10):
+            continue
+
+        # parse a token from the current line
+        parsed_token = ' '.join(line.split(' ')[0:4]).strip()
+
+        if parsed_token in issue_fields_by_friendly:
+            # next field found
+            current_field = issue_fields_by_friendly[parsed_token]
+
+        if current_field.name not in update_object.conflicts:
+            continue
+
+        if current_field.name not in editor_result:
+            editor_result[current_field.name] = []
+
+        editor_result[current_field.name].append(line[len(parsed_token):].strip())
+
+    def preprocess_field_value(field_name, val):
+        if issue_fields[field_name].type is set:
+            return [item[1:].strip() for item in val]
+        else:
+            return ''.join(val)
+
+    # fields need additional preprocessing before being passed to Issue.deserialize()
+    editor_result = {k: preprocess_field_value(k, v) for k, v in editor_result.items()}
+
+    # merge edit results into original Issue
+    edited_issue_dict = update_object.merged_issue.serialize()
+    edited_issue_dict.update(editor_result)
+
+    return Issue.deserialize(edited_issue_dict)

--- a/jira_cli/utils.py
+++ b/jira_cli/utils.py
@@ -2,8 +2,24 @@ import dataclasses
 import datetime
 import decimal
 import enum
+import functools
 
 import arrow
+
+
+@functools.lru_cache()
+def friendly_title(field_name):
+    '''
+    Util function to convert a dataclass field name into a friendly title
+    '''
+    # late import prevents circular dependency
+    from jira_cli.models import Issue  # pylint: disable=import-outside-toplevel,cyclic-import
+    try:
+        for f in dataclasses.fields(Issue):
+            if f.name == field_name:
+                return f.metadata['friendly']
+    except KeyError:
+        return field_name.replace('_', ' ').title()
 
 
 class DeserializeError(ValueError):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     long_description=open('README.md').read(),
     author='Matt Black',
     author_email='dev@mafro.net',
-    url='http://github.com/mafrosis/jira-cli',
+    url='http://github.com/mafrosis/jiracli',
     packages=find_packages(exclude=['test']),
     package_data={'': ['LICENSE']},
     package_dir={'': '.'},
@@ -31,7 +31,7 @@ setup(
     license=open('LICENSE').read(),
     entry_points={
         'console_scripts': [
-            'jira=jira_cli.entrypoint:cli'
+            'jiracli=jira_cli.entrypoint:cli'
         ]
     },
     classifiers=(

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -19,6 +19,50 @@ ISSUE_1 = {
     'diff_to_original': []
 }
 
+ISSUE_1_WITH_ASSIGNEE_DIFF = {
+    'assignee': 'hoganp',
+    'created': '2018-09-24T08:44:06.000+10:00',
+    'creator': 'danil1',
+    'description': 'This is a story or issue',
+    'fixVersions': ['0.1'],
+    'issuetype': 'Story',
+    'key': 'CNTS-71',
+    'labels': [],
+    'lastViewed': None,
+    'priority': 'Normal',
+    'project': 'CNTS',
+    'reporter': 'danil1',
+    'status': 'Story Done',
+    'summary': 'This is the story summary',
+    'updated': '2019-08-20T16:41:19.000+10:00',
+    'estimate': None,
+    'epic_ref': 'EPIC-60',
+    'epic_name': '0.1: Epic in version 0.1',
+    'diff_to_original': [('change', 'assignee', ('hoganp', 'danil1'))]
+}
+
+ISSUE_1_WITH_FIXVERSIONS_DIFF = {
+    'assignee': 'danil1',
+    'created': '2018-09-24T08:44:06.000+10:00',
+    'creator': 'danil1',
+    'description': 'This is a story or issue',
+    'fixVersions': ['0.1', '0.2'],
+    'issuetype': 'Story',
+    'key': 'CNTS-71',
+    'labels': [],
+    'lastViewed': None,
+    'priority': 'Normal',
+    'project': 'CNTS',
+    'reporter': 'danil1',
+    'status': 'Story Done',
+    'summary': 'This is the story summary',
+    'updated': '2019-08-20T16:41:19.000+10:00',
+    'estimate': None,
+    'epic_ref': 'EPIC-60',
+    'epic_name': '0.1: Epic in version 0.1',
+    'diff_to_original': [('remove', 'fixVersions', [(1, '0.2')])]
+}
+
 ISSUE_2 = {
     'assignee': 'danil1',
     'created': '2018-09-24T08:44:06.000+10:00',

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -19,6 +19,27 @@ ISSUE_1 = {
     'diff_to_original': []
 }
 
+ISSUE_1_WITH_UPDATED_DIFF = {
+    'assignee': 'danil1',
+    'created': '2018-09-24T08:44:06.000+10:00',
+    'creator': 'danil1',
+    'description': 'This is a story or issue',
+    'fixVersions': ['0.1'],
+    'issuetype': 'Story',
+    'key': 'CNTS-71',
+    'labels': [],
+    'priority': 'Normal',
+    'project': 'CNTS',
+    'reporter': 'danil1',
+    'status': 'Story Done',
+    'summary': 'This is the story summary',
+    'updated': '2000-08-20T00:00:00.000+10:00',
+    'estimate': None,
+    'epic_ref': 'EPIC-60',
+    'epic_name': '0.1: Epic in version 0.1',
+    'diff_to_original': [('change', 'updated', ('2000-08-20T00:00:00.000+10:00', '2019-08-20T16:41:19+10:00'))]
+}
+
 ISSUE_1_WITH_ASSIGNEE_DIFF = {
     'assignee': 'hoganp',
     'created': '2018-09-24T08:44:06.000+10:00',

--- a/test/sync/test_build_update.py
+++ b/test/sync/test_build_update.py
@@ -1,6 +1,24 @@
-from fixtures import ISSUE_1, ISSUE_1_WITH_ASSIGNEE_DIFF, ISSUE_1_WITH_FIXVERSIONS_DIFF
+from fixtures import (ISSUE_1, ISSUE_1_WITH_ASSIGNEE_DIFF, ISSUE_1_WITH_FIXVERSIONS_DIFF,
+                      ISSUE_1_WITH_UPDATED_DIFF)
 from jira_cli.models import Issue
 from jira_cli.sync import Conflict, _build_update
+
+
+def test_build_update__ignores_readonly_fields():
+    '''
+    Modified readonly fields must be ignored during build_update
+    '''
+    # create unmodified base Issue fixture
+    base_issue = Issue.deserialize(ISSUE_1_WITH_ASSIGNEE_DIFF)
+    # create modified issue as upstream (readonly field is only one modified)
+    updated_issue = Issue.deserialize(ISSUE_1_WITH_UPDATED_DIFF)
+
+    update_obj = _build_update(base_issue, updated_issue)
+
+    assert update_obj.modified == {'assignee'}
+    assert not update_obj.conflicts
+    assert update_obj.merged_issue.assignee == 'hoganp'
+    assert update_obj.merged_issue.updated == base_issue.updated
 
 
 def test_build_update__base_unmodified_and_updated_modified():

--- a/test/sync/test_build_update.py
+++ b/test/sync/test_build_update.py
@@ -1,0 +1,204 @@
+from fixtures import ISSUE_1, ISSUE_1_WITH_ASSIGNEE_DIFF, ISSUE_1_WITH_FIXVERSIONS_DIFF
+from jira_cli.models import Issue
+from jira_cli.sync import Conflict, _build_update
+
+
+def test_build_update__base_unmodified_and_updated_modified():
+    '''
+    Ensure NO conflict when:
+      - base NOT changed
+      - updated changed to field B=1
+    '''
+    # create unmodified base Issue fixture
+    base_issue = Issue.deserialize(ISSUE_1)
+    # create modified issue as updated
+    updated_issue = Issue.deserialize(ISSUE_1_WITH_ASSIGNEE_DIFF)
+
+    update_obj = _build_update(base_issue, updated_issue)
+
+    assert update_obj.modified == {'assignee'}
+    assert not update_obj.conflicts
+    assert update_obj.merged_issue.assignee == 'hoganp'
+
+
+def test_build_update__base_modified_and_updated_unmodified():
+    '''
+    Ensure NO conflict when:
+      - base changed to field A=1
+      - updated NOT changed
+    '''
+    # create a modified base Issue fixture
+    base_issue = Issue.deserialize(ISSUE_1_WITH_ASSIGNEE_DIFF)
+    # create unmodified updated Issue fixture
+    updated_issue = Issue.deserialize(ISSUE_1)
+
+    update_obj = _build_update(base_issue, updated_issue)
+
+    assert update_obj.modified == {'assignee'}
+    assert not update_obj.conflicts
+    assert update_obj.merged_issue.assignee == 'hoganp'
+
+
+def test_build_update__base_modified_on_str_type_and_updated_modified_str_type_returns_conflict():
+    '''
+    Ensure conflict when (for str type):
+      - base changed to field A="1"
+      - updated changed to field A="2"
+    '''
+    # create a modified base Issue fixture
+    base_issue = Issue.deserialize(ISSUE_1_WITH_ASSIGNEE_DIFF)
+    # pass a conflicting modified Issue object (on assignee str)
+    updated_issue = Issue.deserialize(ISSUE_1)
+    updated_issue.assignee = 'murphye'
+
+    update_obj = _build_update(base_issue, updated_issue)
+
+    assert update_obj.modified == {'assignee'}
+    assert update_obj.conflicts == {
+        'assignee': {'original': 'danil1', 'updated': 'murphye', 'base': 'hoganp'}
+    }
+    assert isinstance(update_obj.merged_issue.assignee, Conflict)
+
+
+def test_build_update__base_modified_on_set_type_and_updated_modified_set_type_returns_conflict():
+    '''
+    Ensure conflict when (for set type):
+      - base changed to field A={1,2}
+      - updated changed to field A={1,3}
+    '''
+    # create a modified base Issue fixture
+    base_issue = Issue.deserialize(ISSUE_1_WITH_FIXVERSIONS_DIFF)
+    # pass a conflicting modified Issue object (on fixVersions set)
+    updated_issue = Issue.deserialize(ISSUE_1)
+    updated_issue.fixVersions.add('0.3')
+
+    update_obj = _build_update(base_issue, updated_issue)
+
+    assert update_obj.modified == {'fixVersions'}
+    assert update_obj.conflicts == {
+        'fixVersions': {'original': ['0.1'], 'updated': ['0.1', '0.3'], 'base': ['0.1', '0.2']}
+    }
+    assert isinstance(update_obj.merged_issue.fixVersions, Conflict)
+
+
+def test_build_update__base_nonconflict_changes_returned_in_merged_issue():
+    '''
+    Ensure base changes returned in merged output, along with a conflict when:
+      - base changed to field A=1 and B=1
+      - updated changed to field A=2
+    '''
+    # create a modified base Issue fixture, with an additional modified field
+    base_issue = Issue.deserialize(ISSUE_1_WITH_ASSIGNEE_DIFF)
+    base_issue.summary = 'This is a test'
+    # make a conflicting change on the updated issue
+    updated_issue = Issue.deserialize(ISSUE_1)
+    updated_issue.assignee = 'murphye'
+
+    update_obj = _build_update(base_issue, updated_issue)
+
+    assert update_obj.modified == {'assignee', 'summary'}
+    assert update_obj.conflicts == {
+        'assignee': {'original': 'danil1', 'updated': 'murphye', 'base': 'hoganp'}
+    }
+    assert isinstance(update_obj.merged_issue.assignee, Conflict)
+    assert update_obj.merged_issue.summary == 'This is a test'
+
+
+def test_build_update__updated_nonconflict_changes_returned_in_merged_issue():
+    '''
+    Ensure updated changes returned in merged output, along with a conflict when:
+      - base changed to field A=2
+      - updated changed to field A=1 and B=1
+    '''
+    # create a modified base Issue fixture, with an additional modified field
+    updated_issue = Issue.deserialize(ISSUE_1_WITH_ASSIGNEE_DIFF)
+    updated_issue.summary = 'This is a test'
+    # make a conflicting change on the updated issue
+    base_issue = Issue.deserialize(ISSUE_1)
+    base_issue.assignee = 'murphye'
+
+    update_obj = _build_update(base_issue, updated_issue)
+
+    assert update_obj.modified == {'assignee', 'summary'}
+    assert update_obj.conflicts == {
+        'assignee': {'original': 'danil1', 'updated': 'hoganp', 'base': 'murphye'}
+    }
+    assert isinstance(update_obj.merged_issue.assignee, Conflict)
+    assert update_obj.merged_issue.summary == 'This is a test'
+
+
+def test_build_update__base_modified_and_updated_modified_on_different_fields():
+    '''
+    Ensure NO conflict when:
+      - base changed to field A=1
+      - updated changed to field B=1
+    '''
+    # create modified base Issue fixture
+    base_issue = Issue.deserialize(ISSUE_1_WITH_FIXVERSIONS_DIFF)
+    # create modified issue as updated
+    updated_issue = Issue.deserialize(ISSUE_1_WITH_ASSIGNEE_DIFF)
+
+    update_obj = _build_update(base_issue, updated_issue)
+
+    assert update_obj.modified == {'assignee', 'fixVersions'}
+    assert not update_obj.conflicts
+    assert update_obj.merged_issue.fixVersions == {'0.1', '0.2'}
+    assert update_obj.merged_issue.assignee == 'hoganp'
+
+
+def test_build_update__base_modified_and_updated_modified_on_same_fields_with_same_value():
+    '''
+    Ensure NO conflict when:
+      - base changed to field A=1
+      - updated changed to field A=1
+    '''
+    # create a modified base Issue fixture
+    base_issue = Issue.deserialize(ISSUE_1_WITH_ASSIGNEE_DIFF)
+    # use the same modified Issue as updated (simulates the same change being made on both sides)
+    updated_issue = Issue.deserialize(ISSUE_1_WITH_ASSIGNEE_DIFF)
+
+    update_obj = _build_update(base_issue, updated_issue)
+
+    assert update_obj.modified == {'assignee'}
+    assert not update_obj.conflicts
+    assert update_obj.merged_issue.assignee == 'hoganp'
+
+
+def test_build_update__base_modified_on_multiple_fields_and_updated_modified_on_single_with_same_values():
+    '''
+    Ensure NO conflict when:
+      - base changed to field A=1 and B=2
+      - updated changed to field A=1
+    '''
+    # create a modified base Issue fixture (modified on two fields)
+    base_issue = Issue.deserialize(ISSUE_1_WITH_ASSIGNEE_DIFF)
+    base_issue.summary = 'This is a test'
+    # make same change on single field on updated Issue
+    updated_issue = Issue.deserialize(ISSUE_1_WITH_ASSIGNEE_DIFF)
+
+    update_obj = _build_update(base_issue, updated_issue)
+
+    assert update_obj.modified == {'assignee', 'summary'}
+    assert not update_obj.conflicts
+    assert update_obj.merged_issue.summary == 'This is a test'
+    assert update_obj.merged_issue.assignee == 'hoganp'
+
+
+def test_build_update__base_modified_on_single_field_and_updated_modified_on_multiple_with_same_values():
+    '''
+    Ensure NO conflict when:
+      - base changed to field A=1
+      - updated changed to field A=1 and B=2
+    '''
+    # create a modified base Issue fixture
+    base_issue = Issue.deserialize(ISSUE_1_WITH_ASSIGNEE_DIFF)
+    # make same change, plus another different change on updated Issue
+    updated_issue = Issue.deserialize(ISSUE_1_WITH_ASSIGNEE_DIFF)
+    updated_issue.summary = 'This is a test'
+
+    update_obj = _build_update(base_issue, updated_issue)
+
+    assert update_obj.modified == {'assignee', 'summary'}
+    assert not update_obj.conflicts
+    assert update_obj.merged_issue.summary == 'This is a test'
+    assert update_obj.merged_issue.assignee == 'hoganp'

--- a/test/sync/test_editor_parser.py
+++ b/test/sync/test_editor_parser.py
@@ -1,0 +1,79 @@
+from jira_cli.models import Issue, IssueStatus
+from jira_cli.sync import IssueUpdate, parse_editor_result
+
+from fixtures import ISSUE_1
+
+
+def test_parse_editor_result__handles_str_type():
+    '''
+    Ensure editor text parser handles string type
+    '''
+    editor_result_raw = '# Conflict(s) on Issue CNTS-71\n\n----------------  --------------------------------------\nSummary           [CNTS-71] This is the story summary\nType              Story\nEpic Ref          EPIC-60\nStatus            Story Done\nPriority          Normal\nAssignee          {assignee}\nEstimate\nDescription       This is a story or issue\nFix Version       -  0.1\nLabels\nReporter          danil1\nCreator           danil1\nCreated           a year ago [2018-09-24 08:44:06+10:00]\nUpdated           a year ago [2018-09-24 08:44:06+10:00]\nLast Viewed       a year ago [2018-09-24 08:44:06+10:00]\n----------------  --------------------------------------\n'.format(
+        assignee='hoganp',
+    )
+
+    edited_issue = parse_editor_result(
+        IssueUpdate(merged_issue=Issue.deserialize(ISSUE_1), conflicts={'assignee'}),
+        editor_result_raw,
+    )
+    assert edited_issue.assignee == 'hoganp'
+
+
+def test_parse_editor_result__handles_str_type_over_100_chars():
+    '''
+    Ensure editor text parser handles strings over 100 chars, as they are textwrapped for the editor
+    '''
+    editor_result_raw = '# Conflict(s) on Issue CNTS-71\n\n----------------  --------------------------------------\nSummary           [CNTS-71] This is the story summary\nType              Story\nEpic Ref          EPIC-60\nStatus            Story Done\nPriority          Normal\nAssignee          danil1\nEstimate\nDescription       {description}\nFix Version       -  0.1\nLabels\nReporter          danil1\nCreator           danil1\nCreated           a year ago [2018-09-24 08:44:06+10:00]\nUpdated           a year ago [2018-09-24 08:44:06+10:00]\nLast Viewed       a year ago [2018-09-24 08:44:06+10:00]\n----------------  --------------------------------------\n'.format(
+        description='This is a story or issue '*5,
+    )
+
+    edited_issue = parse_editor_result(
+        IssueUpdate(merged_issue=Issue.deserialize(ISSUE_1), conflicts={'description'}),
+        editor_result_raw,
+    )
+    assert edited_issue.description == str('This is a story or issue '*5).strip()
+
+
+def test_parse_editor_result__handles_set_type():
+    '''
+    Ensure editor text parser handles set type
+    '''
+    editor_result_raw = '# Conflict(s) on Issue CNTS-71\n\n----------------  --------------------------------------\nSummary           [CNTS-71] This is the story summary\nType              Story\nEpic Ref          EPIC-60\nStatus            Story Done\nPriority          Normal\nAssignee          danil1\nEstimate\nDescription       This is a story or issue\nFix Version{fixVersions}\nLabels\nReporter          danil1\nCreator           danil1\nCreated           a year ago [2018-09-24 08:44:06+10:00]\nUpdated           a year ago [2018-09-24 08:44:06+10:00]\nLast Viewed       a year ago [2018-09-24 08:44:06+10:00]\n----------------  --------------------------------------\n'.format(
+        fixVersions='       -  0.1\n       -  0.3',
+    )
+
+    edited_issue = parse_editor_result(
+        IssueUpdate(merged_issue=Issue.deserialize(ISSUE_1), conflicts={'fixVersions'}),
+        editor_result_raw,
+    )
+    assert edited_issue.fixVersions == {'0.1', '0.3'}
+
+
+def test_parse_editor_result__handles_enum_type():
+    '''
+    Ensure editor text parser handles enum type
+    '''
+    editor_result_raw = '# Conflict(s) on Issue CNTS-71\n\n----------------  --------------------------------------\nSummary           [CNTS-71] This is the story summary\nType              Story\nEpic Ref          EPIC-60\nStatus            {status}\nPriority          Normal\nAssignee          danil1\nEstimate\nDescription       This is a story or issue\nFix Version       -  0.1\nLabels\nReporter          danil1\nCreator           danil1\nCreated           a year ago [2018-09-24 08:44:06+10:00]\nUpdated           a year ago [2018-09-24 08:44:06+10:00]\nLast Viewed       a year ago [2018-09-24 08:44:06+10:00]\n----------------  --------------------------------------\n'.format(
+        status=IssueStatus.NotAssessed.value,
+    )
+
+    edited_issue = parse_editor_result(
+        IssueUpdate(merged_issue=Issue.deserialize(ISSUE_1), conflicts={'status'}),
+        editor_result_raw,
+    )
+    assert edited_issue.status == IssueStatus.NotAssessed
+
+
+def test_parse_editor_result__handles_int_type():
+    '''
+    Ensure editor text parser handles int type
+    '''
+    editor_result_raw = '# Conflict(s) on Issue CNTS-71\n\n----------------  --------------------------------------\nSummary           [CNTS-71] This is the story summary\nType              Story\nEpic Ref          EPIC-60\nStatus            Story Done\nPriority          Normal\nAssignee          danil1\nEstimate        {estimate}\nDescription       This is a story or issue\nFix Version       -  0.1\nLabels\nReporter          danil1\nCreator           danil1\nCreated           a year ago [2018-09-24 08:44:06+10:00]\nUpdated           a year ago [2018-09-24 08:44:06+10:00]\nLast Viewed       a year ago [2018-09-24 08:44:06+10:00]\n----------------  --------------------------------------\n'.format(
+        estimate='99',
+    )
+
+    edited_issue = parse_editor_result(
+        IssueUpdate(merged_issue=Issue.deserialize(ISSUE_1), conflicts={'estimate'}),
+        editor_result_raw,
+    )
+    assert edited_issue.estimate == 99

--- a/test/sync/test_pull_issues.py
+++ b/test/sync/test_pull_issues.py
@@ -1,6 +1,6 @@
 from unittest import mock
 
-from fixtures import ISSUE_1, ISSUE_2
+from fixtures import ISSUE_1, ISSUE_1_WITH_ASSIGNEE_DIFF, ISSUE_1_WITH_FIXVERSIONS_DIFF, ISSUE_2
 from jira_cli.models import Issue
 from jira_cli.sync import pull_issues
 
@@ -10,7 +10,7 @@ def test_pull_issues__calls_connect(mock_tqdm, mock_jira):
     '''
     Ensure pull_issues() method calls connect()
     '''
-    mock_jira._jira.search_issues.side_effect = [mock.Mock(total=1), []]
+    mock_jira._jira.search_issues.side_effect = [ mock.Mock(total=1), [] ]
 
     pull_issues(mock_jira)
     assert mock_jira.connect.called
@@ -23,7 +23,7 @@ def test_pull_issues__last_updated_field_creates_filter_query(mock_tqdm, mock_ji
     '''
     mock_jira.config.last_updated = '2019-01-01 00:00'
     mock_jira.load_issues = mock.Mock()
-    mock_jira._jira.search_issues.side_effect = [mock.Mock(total=1), []]
+    mock_jira._jira.search_issues.side_effect = [ mock.Mock(total=1), [] ]
 
     pull_issues(mock_jira)
 
@@ -36,7 +36,7 @@ def test_pull_issues__last_updated_field_causes_filter_from_waaay_back(mock_tqdm
     '''
     Test config.last_updated NOT being set causes a filtered query from 2010-01-01
     '''
-    mock_jira._jira.search_issues.side_effect = [mock.Mock(total=1), []]
+    mock_jira._jira.search_issues.side_effect = [ mock.Mock(total=1), [] ]
 
     pull_issues(mock_jira)
 
@@ -50,7 +50,7 @@ def test_pull_issues__write_issues_and_config_called(mock_tqdm, mock_jira):
     Test write_issues method is called
     Test config.write_to_disk method is called
     '''
-    mock_jira._jira.search_issues.side_effect = [mock.Mock(total=1), []]
+    mock_jira._jira.search_issues.side_effect = [ mock.Mock(total=1), [] ]
 
     pull_issues(mock_jira)
     assert mock_jira.config.write_to_disk.called
@@ -64,10 +64,90 @@ def test_pull_issues__adds_issues_to_self(mock_tqdm, mock_raw_issue_to_object, m
     '''
     # mock Jira API to return two issues
     issues = [Issue.deserialize(ISSUE_1), Issue.deserialize(ISSUE_2)]
-    mock_jira._jira.search_issues.side_effect = [mock.Mock(total=1), issues, []]
+    mock_jira._jira.search_issues.side_effect = [ mock.Mock(total=2), issues, [] ]
 
+    # mock conversion function to return two Issues
     mock_raw_issue_to_object.side_effect = issues
 
     assert len(mock_jira.keys()) == 0
     pull_issues(mock_jira)
     assert len(mock_jira.keys()) == 2
+
+
+@mock.patch('jira_cli.sync.check_resolve_conflicts')
+@mock.patch('jira_cli.sync._raw_issue_to_object')
+@mock.patch('jira_cli.sync.click')
+def test_pull_issues__check_resolve_conflicts_NOT_called_when_updated_issue_NOT_changed(
+        mock_click, mock_raw_issue_to_object, mock_check_resolve_conflicts, mock_jira
+    ):
+    '''
+    Check that check_resolve_conflict is NOT called when the Jira object is empty (ie have no issues)
+    '''
+    # mock search_issues to return single Issue
+    issues = [Issue.deserialize(ISSUE_1)]
+    mock_jira._jira.search_issues.side_effect = [ mock.Mock(total=1), issues, [] ]
+
+    # mock conversion function to return single Issue
+    mock_raw_issue_to_object.side_effect = [Issue.deserialize(ISSUE_1)]
+
+    pull_issues(mock_jira)
+
+    # no conflict is found
+    assert mock_check_resolve_conflicts.called is False
+
+
+@mock.patch('jira_cli.sync.check_resolve_conflicts')
+@mock.patch('jira_cli.sync._raw_issue_to_object')
+@mock.patch('jira_cli.sync.click')
+def test_pull_issues__check_resolve_conflicts_called_when_local_issue_is_modified(
+        mock_click, mock_raw_issue_to_object, mock_check_resolve_conflicts, mock_jira
+    ):
+    '''
+    Check that check_resolve_conflict is called when the Jira object has the Issue already
+    '''
+    # preload the local cache with a modified issue
+    mock_jira['CNTS-71'] = Issue.deserialize(ISSUE_1_WITH_ASSIGNEE_DIFF)
+
+    # mock search_issues to return single object
+    issues = [Issue.deserialize(ISSUE_1)]
+    mock_jira._jira.search_issues.side_effect = [ mock.Mock(total=1), issues, [] ]
+
+    # mock conversion function to return single Issue
+    mock_raw_issue_to_object.side_effect = [Issue.deserialize(ISSUE_1_WITH_FIXVERSIONS_DIFF)]
+
+    pull_issues(mock_jira)
+
+    # conflict found; resolve conflicts called
+    assert mock_check_resolve_conflicts.called is True
+
+
+@mock.patch('jira_cli.sync.check_resolve_conflicts')
+@mock.patch('jira_cli.sync._raw_issue_to_object')
+@mock.patch('jira_cli.sync.click')
+def test_pull_issues__return_from_check_resolve_conflicts_added_to_self(
+        mock_click, mock_raw_issue_to_object, mock_check_resolve_conflicts, mock_jira
+    ):
+    '''
+    Check that return from check_resolve_conflict is added to Jira object (which implements dict)
+    '''
+    # preload the local cache with a modified issue
+    mock_jira['CNTS-71'] = Issue.deserialize(ISSUE_1_WITH_ASSIGNEE_DIFF)
+
+    # mock search_issues to return single object
+    issues = [Issue.deserialize(ISSUE_1)]
+    mock_jira._jira.search_issues.side_effect = [ mock.Mock(total=1), issues, [] ]
+
+    modified_issue = Issue.deserialize(ISSUE_1_WITH_FIXVERSIONS_DIFF)
+
+    # mock conversion function to return single Issue
+    mock_raw_issue_to_object.side_effect = [modified_issue]
+
+    modified_issue.assignee = 'undertest'
+
+    # mock resolve_conflicts function to return modified_issue
+    mock_check_resolve_conflicts.return_value = modified_issue
+
+    pull_issues(mock_jira)
+
+    # validate that return from check_resolve_conflicts is added as CNTS-71
+    assert mock_jira['CNTS-71'].assignee == 'undertest'

--- a/test/sync/test_resolve_conflicts.py
+++ b/test/sync/test_resolve_conflicts.py
@@ -1,0 +1,153 @@
+from unittest import mock
+
+import pytest
+
+from fixtures import ISSUE_1, ISSUE_1_WITH_ASSIGNEE_DIFF, ISSUE_1_WITH_FIXVERSIONS_DIFF
+from jira_cli.models import Issue
+from jira_cli.sync import (check_resolve_conflicts, ConflictResolutionFailed,
+                           IssueUpdate, manual_conflict_resolution)
+
+
+@mock.patch('jira_cli.sync.manual_conflict_resolution')
+@mock.patch('jira_cli.sync._build_update')
+def test_check_resolve_conflicts__doesnt_call_conflict_resolution_on_NO_conflict(mock_build_update, mock_manual_conflict_resolution):
+    '''
+    Ensure that check_resolve_conflicts does NOT call manual_conflict_resolution when no conflicts found
+    '''
+    issue1 = Issue.deserialize(ISSUE_1)
+
+    # mock _build_update to return NO conflicts
+    mock_build_update.return_value = IssueUpdate(merged_issue=issue1)
+
+    check_resolve_conflicts(issue1, issue1)
+
+    # ensure build_update is called
+    assert mock_build_update.called is True
+    # ensure conflict resolution is NOT called
+    assert mock_manual_conflict_resolution.called is False
+
+
+@mock.patch('jira_cli.sync.manual_conflict_resolution')
+@mock.patch('jira_cli.sync._build_update')
+def test_check_resolve_conflicts__returns_result_of_manual_conflict_resolution(mock_build_update, mock_manual_conflict_resolution):
+    '''
+    Ensure that result of manual_conflict_resolution is returned
+    '''
+    merged_issue = Issue.deserialize(ISSUE_1)
+    updated_issue = Issue.deserialize(ISSUE_1_WITH_ASSIGNEE_DIFF)
+
+    # mock _build_update to return conflicts
+    update_obj = IssueUpdate(
+        merged_issue=merged_issue,
+        modified={'assignee'},
+        conflicts={'assignee': {'original': 'danil1', 'updated': 'hoganp', 'base': 'danil1'}}
+    )
+    mock_build_update.return_value = update_obj
+
+    # mock manual_conflict_resolution to return updated issue
+    mock_manual_conflict_resolution.return_value = updated_issue
+
+    resolved_issue = check_resolve_conflicts(merged_issue, updated_issue)
+
+    # ensure build_update AND manual_conflict_resolution are called
+    mock_build_update.assert_called_once_with(merged_issue, updated_issue)
+    mock_manual_conflict_resolution.assert_called_with(update_obj)
+
+    # return value should match return from manual_conflict_resolution
+    assert resolved_issue == updated_issue
+
+
+@mock.patch('jira_cli.sync.click')
+@mock.patch('jira_cli.sync.parse_editor_result')
+def test_manual_conflict_resolution_retries_three_times_on_none_return(mock_parse_editor_result, mock_click):
+    '''
+    A return of None from click.edit() should result in three retries
+    '''
+    issue = Issue.deserialize(ISSUE_1_WITH_ASSIGNEE_DIFF)
+
+    update_obj = IssueUpdate(
+        merged_issue=issue,
+        modified={'assignee'},
+        conflicts={'assignee': {'original': 'danil1', 'updated': 'murphye', 'base': 'hoganp'}}
+    )
+
+    # mock click.edit to return None, which will cause EditorFieldParseFailed to be raised
+    mock_click.edit.return_value = None
+
+    with pytest.raises(ConflictResolutionFailed):
+        manual_conflict_resolution(update_obj)
+
+    assert mock_click.edit.call_count == 3
+    assert not mock_parse_editor_result.called
+
+
+@mock.patch('jira_cli.sync.click')
+@mock.patch('jira_cli.sync.parse_editor_result')
+def test_manual_conflict_resolution_retries_three_times_on_blank_return(mock_parse_editor_result, mock_click):
+    '''
+    A return of blank from click.edit() should result in three retries
+    '''
+    issue = Issue.deserialize(ISSUE_1_WITH_ASSIGNEE_DIFF)
+
+    update_obj = IssueUpdate(
+        merged_issue=issue,
+        modified={'assignee'},
+        conflicts={'assignee': {'original': 'danil1', 'updated': 'murphye', 'base': 'hoganp'}}
+    )
+
+    # mock click.edit to return '', which will cause EditorFieldParseFailed to be raised
+    mock_click.edit.return_value = ''
+
+    with pytest.raises(ConflictResolutionFailed):
+        manual_conflict_resolution(update_obj)
+
+    assert mock_click.edit.call_count == 3
+    assert not mock_parse_editor_result.called
+
+
+@mock.patch('jira_cli.sync.click')
+@mock.patch('jira_cli.sync.parse_editor_result')
+def test_manual_conflict_resolution_handles_three_error_strings_in_editor_return(mock_parse_editor_result, mock_click):
+    '''
+    There are three strings which indicate failure in a conflict resolution string edit
+    Ensure they all raise correctly
+    '''
+    issue = Issue.deserialize(ISSUE_1_WITH_ASSIGNEE_DIFF)
+
+    update_obj = IssueUpdate(
+        merged_issue=issue,
+        modified={'assignee'},
+        conflicts={'assignee': {'original': 'danil1', 'updated': 'murphye', 'base': 'hoganp'}}
+    )
+
+    # mock click.edit to return None, which will cause EditorFieldParseFailed to be raised
+    mock_click.edit.side_effect = [['<<'], ['>>'], ['==']]
+
+    with pytest.raises(ConflictResolutionFailed):
+        manual_conflict_resolution(update_obj)
+
+    assert mock_click.edit.call_count == 3
+    assert not mock_parse_editor_result.called
+
+
+@mock.patch('jira_cli.sync.click')
+@mock.patch('jira_cli.sync.parse_editor_result')
+def test_manual_conflict_resolution_contrived_success_case(mock_parse_editor_result, mock_click):
+    '''
+    If click.edit() returns a non-error, manual_conflict_resolution() should return the same Issue
+    returned from parse_editor_result()
+    '''
+    incoming_issue = Issue.deserialize(ISSUE_1_WITH_ASSIGNEE_DIFF)
+
+    update_obj = IssueUpdate(
+        merged_issue=incoming_issue,
+        modified={'assignee'},
+        conflicts={'assignee': {'original': 'danil1', 'updated': 'murphye', 'base': 'hoganp'}}
+    )
+
+    # mock the return from parse_editor_result()
+    mock_parse_editor_result.return_value = incoming_issue
+
+    resolved_issue = manual_conflict_resolution(update_obj)
+
+    assert resolved_issue == incoming_issue

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -126,13 +126,18 @@ def test_load_config__no_config_file_missing_causes_call_to_get_user_creds(mock_
     assert mock_get_user_creds.called
 
 
+@mock.patch('jira_cli.config.AppConfig')
 @mock.patch('jira_cli.config.Jira')
 @mock.patch('jira_cli.config._get_user_creds')
-def test_load_config__prompt_for_creds_param_causes_call_to_get_user_creds(mock_get_user_creds, mock_jira_class):
+@mock.patch('jira_cli.config.os')
+def test_load_config__prompt_for_creds_param_causes_call_to_get_user_creds(mock_os, mock_get_user_creds, mock_jira_class, mock_appconfig_class):
     '''
     Ensure that passing the prompt_for_creds param causes a call to _get_user_creds()
     '''
-    load_config({'EGG'}, prompt_for_creds=True)
+    # config file doesn't exist
+    mock_os.path.exists.return_value = False
+
+    load_config(prompt_for_creds=True)
 
     assert mock_get_user_creds.called
 


### PR DESCRIPTION
Some substantial refactoring, and a whole new module `sync.py`.

Features:
- Fields can be marked read-only with via `dataclasses.field.metadata`
- Issue.__str__ can now render conflicts like `git` does
- After determining a conflict exists, there is a manual conflict resolution flow using `$EDITOR`, like in `git`