### PR TITLE
Integration testing++

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+.mypy_cache
+.pytest_cache
+.undodir
+.coverage
+.DS_Store
+.gitignore
+.pylintrc
+
+cov_html
+jira_data
+issue_cache.*

--- a/.github/workflows/build_test_publish.yaml
+++ b/.github/workflows/build_test_publish.yaml
@@ -17,17 +17,18 @@ jobs:
 
     - name: Build for python ${{ matrix.python-version }}
       run: |
-        docker-compose build --build-arg PYTHON_VERSION=${{ matrix.python-version }}
+        docker-compose build --build-arg PYTHON_VERSION=${{ matrix.python-version }} jiracli
+        docker-compose build test
 
     - name: Extra build step for python 3.6 (include dataclasses & typing from pypi)
       if: matrix.python-version < 3.7
       run: |
         # Build an updated Docker image including dataclasses lib
         tee Dockerfile.36 > /dev/null <<EOF
-        FROM mafrosis/jiracli
+        FROM mafrosis/jiracli-test
         RUN pip install dataclasses typing
         EOF
-        docker build -f Dockerfile.36 -t mafrosis/jiracli .
+        docker build -f Dockerfile.36 -t mafrosis/jiracli-test .
 
     - name: Lint with pylint
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,8 @@
 __pycache__
 .coverage
 
-# jiracli config
+# jiracli config and issues cache file
 config/
-
-# actual Jira issue data
-issue_cache.*
 
 # pycov report
 cov_html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
 ARG PYTHON_VERSION=3.7
 FROM python:${PYTHON_VERSION}-slim
 
-RUN pip install ipdb
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y vim
 ENV EDITOR=vim
 
-ADD requirements.txt requirements-dev.txt /app/
-RUN pip install -r requirements-dev.txt
+ADD requirements.txt /app/
+RUN pip install -r requirements.txt
 
 ADD README.md LICENSE MANIFEST.in setup.py /app/
 ADD jira_cli /app/jira_cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG PYTHON_VERSION=3.7
-FROM python:$PYTHON_VERSION
+FROM python:${PYTHON_VERSION}-slim
 
 RUN pip install ipdb
 WORKDIR /app

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,3 @@
+FROM mafrosis/jiracli
+ADD requirements-dev.txt /app/
+RUN pip install -r requirements-dev.txt

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,10 @@ all: lint typecheck test
 
 .PHONY: test
 test:
-	docker-compose run --rm --entrypoint=pytest test --cov=jira_cli --cov-report term --cov-report html:cov_html --disable-pytest-warnings test/
+	docker-compose run --rm --entrypoint=pytest test \
+		--cov=jira_cli --cov-report term --cov-report html:cov_html \
+		--disable-pytest-warnings \
+		test/
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,20 @@ all: lint typecheck test
 .PHONY: test
 test:
 	docker-compose run --rm --entrypoint=pytest test \
+		-m 'not integration' \
 		--cov=jira_cli --cov-report term --cov-report html:cov_html \
 		--disable-pytest-warnings \
 		test/
+
+.PHONY: integration
+integration:
+	docker-compose run --rm --entrypoint=pytest test \
+		-m 'integration' \
+		--hostname=locke:8666 \
+		--username=blackm \
+		--password=eggseggs \
+		--cwd=$$(pwd) \
+		test/integration
 
 .PHONY: lint
 lint:
@@ -16,4 +27,4 @@ lint:
 
 .PHONY: typecheck
 typecheck:
-	docker-compose run --rm --entrypoint pytest test --mypy --mypy-ignore-missing-imports jira_cli/
+	docker-compose run --rm --entrypoint=pytest test --mypy --mypy-ignore-missing-imports jira_cli/

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@ all: lint typecheck test
 
 .PHONY: test
 test:
-	docker-compose run --rm --entrypoint=pytest jiracli --cov=jira_cli --cov-report term --cov-report html:cov_html --disable-pytest-warnings test/
+	docker-compose run --rm --entrypoint=pytest test --cov=jira_cli --cov-report term --cov-report html:cov_html --disable-pytest-warnings test/
 
 .PHONY: lint
 lint:
-	docker-compose run --rm --entrypoint=pylint jiracli jira_cli/
-	docker-compose run --rm --entrypoint=pylint jiracli --rcfile=test/.pylintrc test/
+	docker-compose run --rm --entrypoint=pylint test jira_cli/
+	docker-compose run --rm --entrypoint=pylint test --rcfile=test/.pylintrc test/
 
 .PHONY: typecheck
 typecheck:
-	docker-compose run --rm --entrypoint pytest jiracli --mypy --mypy-ignore-missing-imports jira_cli/
+	docker-compose run --rm --entrypoint pytest test --mypy --mypy-ignore-missing-imports jira_cli/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,15 @@ services:
       - ./jira_cli:/app/jira_cli
       - ./test:/app/test
       - ./config:/root/.config/jiracli
+
+  test:
+    image: mafrosis/jiracli-test
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+    volumes:
+      - ./jira_cli:/app/jira_cli
+      - ./test:/app/test
       - ./.pylintrc:/app/.pylintrc
 
   jira:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
     volumes:
       - ./jira_cli:/app/jira_cli
       - ./test:/app/test
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /tmp:/tmp
+      - ./pytest.ini:/app/pytest.ini
       - ./.pylintrc:/app/.pylintrc
 
   jira:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,10 @@ services:
     build:
       context: .
     volumes:
-      - ./:/app
+      - ./jira_cli:/app/jira_cli
+      - ./test:/app/test
       - ./config:/root/.config/jiracli
-      - /app/.git
-      - /app/jira_cli.egg-info
+      - ./.pylintrc:/app/.pylintrc
 
   jira:
     image: mafrosis/jira

--- a/jira_cli/auth.py
+++ b/jira_cli/auth.py
@@ -15,7 +15,7 @@ from jira_cli.exceptions import FailedAuthError, JiraUnavailable, NoAuthenticati
 from jira_cli.models import ProjectMeta, OAuth
 
 
-def authenticate(project_meta: ProjectMeta, username: Optional[str]=None,
+def authenticate(project_meta: ProjectMeta, username: Optional[str]=None, password: Optional[str]=None,
                  oauth_consumer_key: Optional[str]=None, oauth_private_key_path: Optional[str]=None):
     '''
     Authenticate against hostname with either basic-auth or oAuth
@@ -33,25 +33,28 @@ def authenticate(project_meta: ProjectMeta, username: Optional[str]=None,
 
     elif username:
         # ask for password and validate creds
-        get_user_creds(project_meta, username)
+        get_user_creds(project_meta, username, password)
 
     else:
         raise NoAuthenticationMethod
 
 
-def get_user_creds(project_meta: ProjectMeta, username: Optional[str]=None):
+def get_user_creds(project_meta: ProjectMeta, username: Optional[str]=None, password: Optional[str]=None):
     '''
     Accept username/password and validate against Jira server
 
     Params:
         project_meta:  Properties of the project we're authenticating against
         username:      Basic auth username
+        password:      Basic auth password
     '''
     project_meta.username = username
     if not project_meta.username:
         project_meta.username = click.prompt('Username', type=str)
 
-    project_meta.password = click.prompt('Password', type=str, hide_input=True)
+    project_meta.password = password
+    if not project_meta.password:
+        project_meta.password = click.prompt('Password', type=str, hide_input=True)
 
     # validate Jira connection details
     if project_meta.username and project_meta.password:

--- a/jira_cli/config.py
+++ b/jira_cli/config.py
@@ -30,3 +30,10 @@ def load_config():
         config = AppConfig()
 
     return config
+
+
+def get_cache_filepath() -> str:
+    '''
+    Return the path to jiracli offline issues cache file
+    '''
+    return os.path.join(click.get_app_dir(__title__), 'issue_cache.jsonl')

--- a/jira_cli/entrypoint.py
+++ b/jira_cli/entrypoint.py
@@ -96,10 +96,11 @@ def cli_push(ctx):
 @cli.command(name='clone')
 @click.argument('project_uri')
 @click.option('--username', help='Basic auth username to authenicate with')
+@click.option('--password', help='Basic auth password (use with caution!)')
 @click.option('--oauth-app', default='jiracli', help='Jira Application Link consumer name')
 @click.option('--oauth-private-key', help='oAuth private key', type=click.Path(exists=True))
 @click.pass_context
-def cli_clone(ctx, project_uri: str, username: str=None, oauth_app: str=None, oauth_private_key: str=None):
+def cli_clone(ctx, project_uri: str, username: str=None, password: str=None, oauth_app: str=None, oauth_private_key: str=None):
     '''
     Clone a Jira project to offline
 
@@ -131,7 +132,7 @@ def cli_clone(ctx, project_uri: str, username: str=None, oauth_app: str=None, oa
         raise click.Abort
 
     click.echo(f'Cloning project {project.key} from {project.jira_server}')
-    authenticate(project, username, oauth_app, oauth_private_key)
+    authenticate(project, username, password, oauth_app, oauth_private_key)
     click.echo(f'Authenticated with {project.jira_server}')
 
     try:

--- a/jira_cli/entrypoint.py
+++ b/jira_cli/entrypoint.py
@@ -124,9 +124,13 @@ def cli_clone(ctx, project_uri: str, username: str=None, oauth_app: str=None, oa
         protocol=uri.scheme,
         hostname=uri.netloc,
     )
-    click.echo(f'Cloning project {project.key} from {project.jira_server}')
 
     jira = Jira()
+    if project.id in jira.config.projects:
+        click.echo(f'Already cloned {project.project_uri}')
+        raise click.Abort
+
+    click.echo(f'Cloning project {project.key} from {project.jira_server}')
     authenticate(project, username, oauth_app, oauth_private_key)
     click.echo(f'Authenticated with {project.jira_server}')
 

--- a/jira_cli/main.py
+++ b/jira_cli/main.py
@@ -219,6 +219,11 @@ class Jira(collections.abc.MutableMapping):
         new_issue: Issue = jiraapi_object_to_issue(project, issue)
         self[new_issue.key] = new_issue  # pylint: disable=no-member
 
+        if new_issue.issuetype == 'Epic':  # pylint: disable=no-member
+            # relink any issue linked to this epic to the new Jira-generated key
+            for linked_issue in [i for i in self.values() if i.epic_ref == temp_key]:
+                linked_issue.epic_ref = new_issue.key  # pylint: disable=no-member
+
         # remove the placeholder Issue
         del self[temp_key]
 

--- a/jira_cli/sync.py
+++ b/jira_cli/sync.py
@@ -593,9 +593,9 @@ def push_issues(jira: 'Jira', verbose: bool=False):
     #  1. Push existing issues with local changes first
     issues_to_push: List[Issue] = [i for i in jira.values() if i.diff_to_original and i.exists]
     #  2. Push new epics
-    issues_to_push.extend(i for i in jira.values() if not i.exists and i.status == 'Epic')
+    issues_to_push.extend(i for i in jira.values() if not i.exists and i.issuetype == 'Epic')
     #  3. Push all other new issues
-    issues_to_push.extend(i for i in jira.values() if not i.exists and i.status != 'Epic')
+    issues_to_push.extend(i for i in jira.values() if not i.exists and i.issuetype != 'Epic')
 
     if verbose:
         total = _run(issues_to_push)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    integration: marks tests as integration (see README)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 docker
 ipdb
 pylint
-pytest
+pytest<5.4
 pytest-cov
 pytest-mypy
 pytest-sugar

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+ipdb
 pylint
 pytest
 pytest-cov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+docker
 ipdb
 pylint
 pytest

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,11 @@
+import random
+import string
+import tempfile
 from unittest import mock
 
+from requests.auth import HTTPBasicAuth
+import requests
+import docker
 import jira as mod_jira
 import pytest
 
@@ -7,7 +13,7 @@ from jira_cli.main import Jira
 from jira_cli.models import AppConfig, CustomFields, IssueType, ProjectMeta
 
 
-@pytest.fixture()
+@pytest.fixture
 def project():
     '''
     Fixture representing a configured Jira project
@@ -23,7 +29,7 @@ def project():
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 @mock.patch('jira_cli.main.load_config')
 def mock_jira_core(mock_load_config, project):
     '''
@@ -37,7 +43,7 @@ def mock_jira_core(mock_load_config, project):
     return jira
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_jira(mock_jira_core):
     '''
     Mock additional methods of Jira class
@@ -48,3 +54,133 @@ def mock_jira(mock_jira_core):
     mock_jira_core.new_issue = mock.Mock()
     mock_jira_core.get_project_meta = mock.Mock()
     return mock_jira_core
+
+
+def pytest_addoption(parser):
+    '''
+    Add extra parameters to pytest for integration tests
+    '''
+    parser.addoption('--hostname', action='store')
+    parser.addoption('--username', action='store')
+    parser.addoption('--password', action='store')
+    parser.addoption('--cwd', action='store')
+
+
+@pytest.fixture
+def jira_project(request, run_in_docker):
+    '''
+    Create a new Jira project on a real instance of Jira, using supplied parameters.
+
+    Yield the newly created project's ID for integration testing, and then cleanup the project when
+    finished.
+    '''
+    hostname = request.config.getoption('--hostname')
+    username = request.config.getoption('--username')
+    password = request.config.getoption('--password')
+    cwd = request.config.getoption('--cwd')
+
+    if not hostname or not username or not password or not cwd:
+        raise Exception(
+            'pytest: error the following arguments are required: --username, --hostname, --password, --cwd'
+        )
+
+    # create random 8 char uppercase string
+    project_key = ''.join(random.choice(string.ascii_uppercase) for _ in range(8))
+
+    # create new project in Jira
+    resp = requests.post(
+        f'http://{hostname}/rest/api/2/project',
+        auth=HTTPBasicAuth(username, password),
+        json={
+            'key': project_key,
+            'lead': 'blackm',
+            'name': project_key,
+            'projectTypeKey': 'software',
+            'projectTemplateKey': 'com.pyxis.greenhopper.jira:gh-scrum-template',
+        },
+    )
+    if resp.status_code > 205:
+        raise Exception
+
+    # fetch screens for this new project
+    resp = requests.get(
+        f'http://{hostname}/rest/api/2/screens',
+        auth=HTTPBasicAuth(username, password),
+    )
+    screen_ids = [x['id'] for x in resp.json() if x['name'][0:8] == project_key]
+
+    # retrieve the screen's "availableFields", to find the id of the "Story Points" custom field
+    resp = requests.get(
+        f'http://{hostname}/rest/api/2/screens/{screen_ids[0]}/availableFields',
+        auth=HTTPBasicAuth(username, password),
+    )
+    estimate_customfield_id = [x['id'] for x in resp.json() if x['name'] == 'Story Points'][0]
+
+    # add "Story Points" (aka Issue.estimate) to every screen in the project
+    for screen_id in screen_ids:
+        # iterate the screen's tabs (there should be only 1 for a new project)
+        resp = requests.get(
+            f'http://{hostname}/rest/api/2/screens/{screen_id}/tabs',
+            auth=HTTPBasicAuth(username, password),
+        )
+        for tab_id in [x['id'] for x in resp.json()]:
+            resp = requests.post(
+                f'http://{hostname}/rest/api/2/screens/{screen_id}/tabs/{tab_id}/fields',
+                auth=HTTPBasicAuth(username, password),
+                json={
+                    'fieldId': estimate_customfield_id,
+                },
+            )
+
+    # clone the new project
+    run_in_docker(
+        project_key,
+        f'clone --username {username} --password {password} http://{hostname}/{project_key}'
+    )
+    yield project_key
+
+    # delete the Jira test project
+    resp = requests.delete(
+        f'http://{hostname}/rest/api/2/project/{project_key}',
+        auth=HTTPBasicAuth(username, password),
+    )
+
+
+@pytest.fixture
+def run_in_docker(request):
+    '''
+    Run a command in docker during an integration test run
+    '''
+    cwd = request.config.getoption('--cwd')
+    if not cwd:
+        raise Exception(
+            'pytest: error the following arguments are required: --username, --hostname, --password, --cwd'
+        )
+
+    tmpdir = tempfile.TemporaryDirectory()
+    print(f'Test working directory {tmpdir.name}')
+
+    client = docker.from_env()
+
+    def wrapped(project_key: str, cmd: str):
+        try:
+            stdout = client.containers.run(
+                'mafrosis/jiracli',
+                command=cmd,
+                remove=True,
+                stderr=True,
+                mounts=[
+                    docker.types.Mount(type='bind', source=f'{cwd}/jira_cli', target='/app/jira_cli', read_only=True),
+                    docker.types.Mount(type='bind', source=tmpdir.name, target='/root/.config/jiracli'),
+                ],
+            )
+            # containers.run returns bytes, so encode, print and return
+            ret = stdout.decode('utf8')
+            print(ret)
+            return ret
+
+        except docker.errors.ContainerError as e:
+            raise Exception(f'Docker run failed during integration test ({e})')
+
+    yield wrapped
+    tmpdir.cleanup()

--- a/test/integration/test_multiple_issue_push.py
+++ b/test/integration/test_multiple_issue_push.py
@@ -1,0 +1,18 @@
+'''
+End-to-end integration tests which use a real instance of Jira
+'''
+import pytest
+
+
+@pytest.mark.integration
+def test_push_epics_with_issues_created_offline(jira_project, run_in_docker):
+    '''
+    Ensure offline creation of epic and linked issue push to Jira correctly
+    '''
+    run_in_docker(jira_project, f'new {jira_project} Epic EGGpic --epic-name EGGpic')
+    run_in_docker(jira_project, f'new {jira_project} Story stozza1 --epic-ref EGGpic')
+    run_in_docker(jira_project, f'new {jira_project} Epic EGGpic2 --epic-name EGGpic2')
+
+    output = run_in_docker(jira_project, '--verbose push')
+
+    assert 'INFO: Pushed 3 of 3 issues' in output

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -32,10 +32,10 @@ def test_authenticate__calls_get_user_creds_when_username_passed(mock_click, moc
     '''
     project_meta = ProjectMeta(key='test')
 
-    authenticate(project_meta, username='egg')
+    authenticate(project_meta, username='egg', password='bacon')
 
     assert not mock_oauth_dance.called
-    mock_get_user_creds.assert_called_with(project_meta, 'egg')
+    mock_get_user_creds.assert_called_with(project_meta, 'egg', 'bacon')
 
 
 @pytest.mark.parametrize('project_meta', [

--- a/test/test_entrypoint.py
+++ b/test/test_entrypoint.py
@@ -39,7 +39,7 @@ def test_debug_flag_sets_logger_to_debug_level(mock_jira_local, mock_jira):
 CLI_COMMAND_MAPPING = [
     ('ls', tuple(), 1),
     ('show', ('issue1',), 1),
-    ('clone', ('https://jira.atlassian.com/TEST',), 0),
+    ('clone', ('https://jira.atlassian.com/TEST1',), 0),
     ('new', ('TEST', 'Story', 'Summary'), 0),
     ('pull', tuple(), 0),
     ('push', tuple(), 1),


### PR DESCRIPTION
Add the `pytest` plumbing required for integration testing in 0504d0f. This has been run entirely manually (as the jira install is not fully headless). Tests run using docker-in-docker via `docker-py` library, to simulate sequential calls to the `jiracli` app.

There are a couple of functional changes to the app to support this in b448840, cb16fff & 26cfeab.

Also, a whole bunch of docker-related improvements.

Finally, the failing test-case which drove this PR is fixed in cf51576.