### PR TITLE
Rename project ahead of 0.0.1 release

### DIFF
--- a/.github/workflows/build_test_publish.yaml
+++ b/.github/workflows/build_test_publish.yaml
@@ -17,7 +17,7 @@ jobs:
 
     - name: Build for python ${{ matrix.python-version }}
       run: |
-        docker-compose build --build-arg PYTHON_VERSION=${{ matrix.python-version }} jiracli
+        docker-compose build --build-arg PYTHON_VERSION=${{ matrix.python-version }} jira-offline
         docker-compose build test
 
     - name: Extra build step for python 3.6 (include dataclasses & typing from pypi)
@@ -25,10 +25,10 @@ jobs:
       run: |
         # Build an updated Docker image including dataclasses lib
         tee Dockerfile.36 > /dev/null <<EOF
-        FROM mafrosis/jiracli-test
+        FROM mafrosis/jira-offline-test
         RUN pip install dataclasses typing
         EOF
-        docker build -f Dockerfile.36 -t mafrosis/jiracli-test .
+        docker build -f Dockerfile.36 -t mafrosis/jira-offline-test .
 
     - name: Lint with pylint
       run: |
@@ -46,7 +46,7 @@ jobs:
       if: matrix.python-version == 3.7 && github.ref == 'refs/heads/master'
       run: |
         echo "$GITHUB_TOKEN" | docker login -u mafrosis --password-stdin docker.pkg.github.com
-        docker tag mafrosis/jiracli docker.pkg.github.com/mafrosis/jiracli/jiracli:dev
-        docker push docker.pkg.github.com/mafrosis/jiracli/jiracli:dev
+        docker tag mafrosis/jira-offline docker.pkg.github.com/mafrosis/jira-offline/jira-offline:dev
+        docker push docker.pkg.github.com/mafrosis/jira-offline/jira-offline:dev
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ jira_data/
 
 # mypy type linting
 .mypy_cache
+
+# distutils
+build
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 __pycache__
 .coverage
 
-# jiracli config and issues cache file
+# config and issues cache file
 config/
 
 # pycov report

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ ADD README.md LICENSE MANIFEST.in setup.py /app/
 ADD jira_cli /app/jira_cli
 RUN pip install -e .
 
-ENTRYPOINT ["jiracli"]
+ENTRYPOINT ["jira"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,3 +1,3 @@
-FROM mafrosis/jiracli
+FROM mafrosis/jira-offline
 ADD requirements-dev.txt /app/
 RUN pip install -r requirements-dev.txt

--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,14 @@ lint:
 .PHONY: typecheck
 typecheck:
 	docker-compose run --rm --entrypoint=pytest test --mypy --mypy-ignore-missing-imports jira_cli/
+
+
+.PHONY: package
+package:
+	rm -rf jira_offline.egg-info dist
+	python3 setup.py sdist bdist_wheel
+
+.PHONY: publish
+publish:
+	twine check dist/*
+	twine upload --repository=test dist/*

--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ A few options exist:
 
 Using the docker image published on Github, the following will get you going very quickly:
 
-    docker pull docker.pkg.github.com/mafrosis/jiracli/jiracli:dev
-    docker run --rm -it docker.pkg.github.com/mafrosis/jiracli/jiracli:dev
+    docker pull docker.pkg.github.com/mafrosis/jira-offline/jira-offline:dev
+    docker run --rm -it docker.pkg.github.com/mafrosis/jira-offline/jira-offline:dev
 
 ### Install with pip
 
-    pip install git+https://github.com/mafrosis/jiracli.git@master
+    pip install git+https://github.com/mafrosis/jira-offline.git@master
 
 ### Clone and use compose
 
-    git clone https://github.com/mafrosis/jiracli.git
-    cd jiracli
-    docker-compose build jiracli
-    docker-compose run --rm jiracli
+    git clone https://github.com/mafrosis/jira-offline.git
+    cd jira-offline
+    docker-compose build jira-offline
+    docker-compose run --rm jira-offline
 
 
 Known Limitations
@@ -49,7 +49,7 @@ Known Limitations
 Quick Start
 -----------
 
-**NB**: The following examples assume `jiracli` is available in `$PATH`
+**NB**: The following examples assume `jira` is available in `$PATH`
 
 ### Clone
 
@@ -65,7 +65,7 @@ There are two auth options, basic and oAuth.
 Basic auth is quick and takes your existing username and password. Beware that this will *write your
 password into the config file on disk*.
 
-    jiracli clone --username benji https://jira.atlassian.com/PROJ
+    jira clone --username benji https://jira.atlassian.com/PROJ
 
 You will be prompted for your password.
 
@@ -74,19 +74,19 @@ You will be prompted for your password.
 oAuth is preferred, as it's token based and doesn't require your password. However it requires the
 setup of an `Application Link` on the Jira server.
 
-    jiracli clone --oauth-private-key=applink.pem https://jira.atlassian.com/PROJ
+    jira clone --oauth-private-key=applink.pem https://jira.atlassian.com/PROJ
 
 
 How To Use
 ----------
 
-**NB**: The following examples assume `jiracli` is available in `$PATH`
+**NB**: The following examples assume `jira` is available in `$PATH`
 
 ### How to configure a new Jira project
 
 Use `clone` to add a project:
 
-    jiracli clone https://jira.atlassian.com/PROJ
+    jira clone https://jira.atlassian.com/PROJ
 
 
 Extending This Tool

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,17 @@
 version: '3'
 
 services:
-  jiracli:
-    image: mafrosis/jiracli
+  jira-offline:
+    image: mafrosis/jira-offline
     build:
       context: .
     volumes:
       - ./jira_cli:/app/jira_cli
       - ./test:/app/test
-      - ./config:/root/.config/jiracli
+      - ./config:/root/.config/jira-offline
 
   test:
-    image: mafrosis/jiracli-test
+    image: mafrosis/jira-offline-test
     build:
       context: .
       dockerfile: Dockerfile.test

--- a/jira_cli/__init__.py
+++ b/jira_cli/__init__.py
@@ -5,6 +5,6 @@
 __title__ = 'jira-offline'
 __version__ = '0.0.1'
 __build__ = 0x000001
-__author__ = 'Matt Black'
-__license__ = 'Simplified BSD License'
-__copyright__ = 'Copyright 2019 Matt Black'
+__author__ = 'mafrosis'
+__license__ = 'Simplified MIT License'
+__copyright__ = 'Copyright 2020 Matt Black'

--- a/jira_cli/__init__.py
+++ b/jira_cli/__init__.py
@@ -2,7 +2,7 @@
 # jira
 #
 
-__title__ = 'jiracli'
+__title__ = 'jira-offline'
 __version__ = '0.0.1'
 __build__ = 0x000001
 __author__ = 'Matt Black'

--- a/jira_cli/auth.py
+++ b/jira_cli/auth.py
@@ -110,7 +110,7 @@ def oauth_dance(project: ProjectMeta, consumer_key: str, key_cert_data: str, ver
 
     webbrowser.open_new(auth_url)
 
-    click.echo(f'\nPlease visit this URL to authorize jiracli to access your data:\n    {auth_url}\n')
+    click.echo(f'\nPlease visit this URL to authorize jira-offline to access your data:\n    {auth_url}\n')
     click.confirm(f'Have you authorized this program to connect on your behalf to {jira_url}?', abort=True)
 
     # step 3: get access tokens for validated user

--- a/jira_cli/config.py
+++ b/jira_cli/config.py
@@ -34,6 +34,6 @@ def load_config():
 
 def get_cache_filepath() -> str:
     '''
-    Return the path to jiracli offline issues cache file
+    Return the path to jira-offline issues cache file
     '''
     return os.path.join(click.get_app_dir(__title__), 'issue_cache.jsonl')

--- a/jira_cli/entrypoint.py
+++ b/jira_cli/entrypoint.py
@@ -99,7 +99,7 @@ def cli_push(ctx):
 @click.argument('project_uri')
 @click.option('--username', help='Basic auth username to authenicate with')
 @click.option('--password', help='Basic auth password (use with caution!)')
-@click.option('--oauth-app', default='jiracli', help='Jira Application Link consumer name')
+@click.option('--oauth-app', default='jira-offline', help='Jira Application Link consumer name')
 @click.option('--oauth-private-key', help='oAuth private key', type=click.Path(exists=True))
 @click.pass_context
 def cli_clone(ctx, project_uri: str, username: str=None, password: str=None, oauth_app: str=None, oauth_private_key: str=None):

--- a/jira_cli/exceptions.py
+++ b/jira_cli/exceptions.py
@@ -72,7 +72,7 @@ class ProjectNotConfigured(BaseAppException):
     def format_message(self):
         return (
             'The project {key} is not currently configured! You must first load the project with '
-            'this command:\n\n  jiracli clone https://jira.atlassian.com:8080/{key}\n'.format(
+            'this command:\n\n  jira clone https://jira.atlassian.com:8080/{key}\n'.format(
                 key=self.message
             )
         )

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,8 @@
 #! /usr/bin/env python
 
-import os
-import sys
-
 from setuptools import setup, find_packages
 
 import jira_cli
-
-if sys.argv[-1] == 'publish':
-    os.system('python setup.py sdist upload')
-    sys.exit()
 
 REQUIRES = [
     open('requirements.txt').read()
@@ -19,6 +12,7 @@ setup(
     name='jira-offline',
     version=jira_cli.__version__,
     description='CLI for using Jira offline',
+    long_description_content_type='text/markdown',
     long_description=open('README.md').read(),
     author='Matt Black',
     author_email='dev@mafro.net',
@@ -42,6 +36,8 @@ setup(
         'Natural Language :: English',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ),
 )

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     package_dir={'': '.'},
     include_package_data=True,
     install_requires=REQUIRES,
-    license=open('LICENSE').read(),
+    license='MIT License',
     entry_points={
         'console_scripts': [
             'jira=jira_cli.entrypoint:cli'
@@ -40,7 +40,7 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'Natural Language :: English',
-        'License :: OSI Approved :: BSD License',
+        'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.7',
     ),

--- a/setup.py
+++ b/setup.py
@@ -16,13 +16,13 @@ REQUIRES = [
 ]
 
 setup(
-    name='jira_cli',
+    name='jira-offline',
     version=jira_cli.__version__,
-    description='Jira CLI automation tool',
+    description='CLI for using Jira offline',
     long_description=open('README.md').read(),
     author='Matt Black',
     author_email='dev@mafro.net',
-    url='http://github.com/mafrosis/jiracli',
+    url='http://github.com/mafrosis/jira-offline',
     packages=find_packages(exclude=['test']),
     package_data={'': ['LICENSE']},
     package_dir={'': '.'},
@@ -31,7 +31,7 @@ setup(
     license=open('LICENSE').read(),
     entry_points={
         'console_scripts': [
-            'jiracli=jira_cli.entrypoint:cli'
+            'jira=jira_cli.entrypoint:cli'
         ]
     },
     classifiers=(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -169,13 +169,13 @@ def run_in_docker(request):
     def wrapped(project_key: str, cmd: str):
         try:
             stdout = client.containers.run(
-                'mafrosis/jiracli',
+                'mafrosis/jira-offline',
                 command=cmd,
                 remove=True,
                 stderr=True,
                 mounts=[
                     docker.types.Mount(type='bind', source=f'{cwd}/jira_cli', target='/app/jira_cli', read_only=True),
-                    docker.types.Mount(type='bind', source=tmpdir.name, target='/root/.config/jiracli'),
+                    docker.types.Mount(type='bind', source=tmpdir.name, target='/root/.config/jira-offline'),
                 ],
             )
             # containers.run returns bytes, so encode, print and return

--- a/test/test_entrypoint.py
+++ b/test/test_entrypoint.py
@@ -66,7 +66,7 @@ def test_cli_smoketest(mock_authenticate, mock_push_issues, mock_pull_issues,
     Dumb smoke test function to check for errors in application CLI
     Failures here often uncover untested parts of the codebase
 
-    This function tests when the jiracli issue cache has a single issue
+    This function tests when the jira-offline issue cache has a single issue
     '''
     # set function-local instance of Jira class to our test mock
     mock_jira_local.return_value = mock_jira
@@ -94,7 +94,7 @@ def test_cli_smoketest_empty(mock_authenticate, mock_push_issues, mock_pull_issu
     Dumb smoke test function to check for errors in application CLI
     Failures here often uncover untested parts of the codebase
 
-    This function tests when the jiracli issue cache is empty
+    This function tests when the jira-offline issue cache is empty
     '''
     # set function-local instance of Jira class to our test mock
     mock_jira_local.return_value = mock_jira


### PR DESCRIPTION
Rename the project so `jiracli` can graduate to alpha:

https://test.pypi.org/project/jira-offline/

Also updated the entrypoint script name to `jira` in light of the change, and refreshed the config for pushing to pypi