### PR TITLE
Serializer updates

### DIFF
--- a/jira_offline/models.py
+++ b/jira_offline/models.py
@@ -192,12 +192,13 @@ class Issue(DataclassSerializer):  # pylint: disable=too-many-instance-attribute
 
     # local-only dict which represents serialized Issue last seen on Jira server
     # this property is not written to cache and is created at runtme from diff_to_original
-    original: Dict[str, Any] = field(default_factory=dict, repr=False)
+    original: Dict[str, Any] = field(default_factory=dict, metadata={'rw': ''})
 
     # patch of current Issue to dict last seen on Jira server
-    diff_to_original: Optional[list] = field(default=None, repr=False)
+    # "rw" flag instructs serializer to deserialize this only; do not include during serialize()
+    diff_to_original: Optional[list] = field(default=None, metadata={'rw': 'r'})
 
-    project_ref: Optional[ProjectMeta] = field(default=None, repr=False)
+    project_ref: Optional[ProjectMeta] = field(default=None, metadata={'rw': ''})
 
     @classmethod
     @functools.lru_cache(maxsize=1)

--- a/jira_offline/models.py
+++ b/jira_offline/models.py
@@ -29,7 +29,7 @@ from jira_offline.utils.serializer import DataclassSerializer
 class CustomFields(DataclassSerializer):
     epic_ref: str = field(default='')
     epic_name: str = field(default='')
-    estimate: str = field(default='')
+    estimate: Optional[str] = field(default='')
 
     def __bool__(self):
         if self.epic_ref and self.epic_name and self.estimate:

--- a/jira_offline/sync.py
+++ b/jira_offline/sync.py
@@ -19,7 +19,7 @@ from jira_offline.exceptions import (EpicNotFound, EstimateFieldUnavailable, Fai
                                      FailedPullingProjectMeta, JiraApiError)
 from jira_offline.models import Issue, ProjectMeta
 from jira_offline.utils import critical_logger, friendly_title, get_field_by_name
-from jira_offline.utils.serializer import DeserializeError, is_optional_type
+from jira_offline.utils.serializer import DeserializeError, istype
 from jira_offline.utils.api import get as api_get
 from jira_offline.utils.convert import jiraapi_object_to_issue, issue_to_jiraapi_update
 
@@ -430,7 +430,7 @@ def parse_editor_result(update_object: IssueUpdate, editor_result_raw: str) -> I
     summary_prefix = f'[{update_object.merged_issue.key}]'
 
     def preprocess_field_value(field_name, val):
-        if is_optional_type(get_field_by_name(Issue, field_name).type, set):
+        if istype(get_field_by_name(Issue, field_name).type, set):
             return [item[1:].strip() for item in val]
         else:
             output = ''.join(val)

--- a/jira_offline/utils/serializer.py
+++ b/jira_offline/utils/serializer.py
@@ -174,6 +174,13 @@ class DataclassSerializer:
         data = {}
 
         for f in dataclasses.fields(cls):
+            # check for field read/write metadata, which determines if fields are ignored
+            # if the "r" field is not present, do not deserialize this field
+            rw_flag = f.metadata.get('rw', 'rw')
+            if 'r' not in rw_flag:
+                #print(f)
+                continue
+
             raw_value = None
 
             _validate_optional_fields_have_a_default(f)
@@ -217,8 +224,7 @@ class DataclassSerializer:
 
     def serialize(self) -> dict:
         '''
-        Serialize dataclass to JSON-compatible dict. Includes only fields with repr=True (the
-        dataclass.field default).
+        Serialize dataclass to JSON-compatible dict.
 
         Returns:
             A JSON-compatible dict
@@ -226,7 +232,10 @@ class DataclassSerializer:
         data = {}
 
         for f in dataclasses.fields(self):
-            if f.repr is False:
+            # check for field read/write metadata, which determines if fields are ignored
+            # if the "w" field is not present, do not serialize this field
+            rw_flag = f.metadata.get('rw', 'rw')
+            if 'w' not in rw_flag:
                 continue
 
             # pull value from dataclass field name, or by property name, if defined on the dataclass.field

--- a/jira_offline/utils/serializer.py
+++ b/jira_offline/utils/serializer.py
@@ -60,6 +60,9 @@ def deserialize_value(type_: type, value: Any) -> Any:  # pylint: disable=too-ma
     '''
     Utility function to deserialize `value` into `type_`. Used by DataclassSerializer.
     '''
+    if value is None:
+        return None
+
     if typing_inspect.is_optional_type(type_):
         # for typing.Optional, first arg is the real type and second arg is typing.NoneType
         type_ = typing_inspect.get_args(type_)[0]

--- a/jira_offline/utils/serializer.py
+++ b/jira_offline/utils/serializer.py
@@ -41,9 +41,9 @@ def get_enum(type_: type) -> Optional[type]:
     return None
 
 
-def is_optional_type(type_: type, typ: type) -> bool:
+def istype(type_: type, typ: type) -> bool:
     '''
-    Return True if type_ is typ, else return False
+    Return True if type_ is typ, else return False. Handles Optional types.
     '''
     if typing_inspect.is_optional_type(type_):
         # for typing.Optional, the real type is the first arg, and second is typing.NoneType

--- a/jira_offline/utils/serializer.py
+++ b/jira_offline/utils/serializer.py
@@ -185,9 +185,8 @@ class DataclassSerializer:
 
             except KeyError as e:
                 # handle key missing from passed dict
-                if isinstance(f.default, dataclasses._MISSING_TYPE) and \
-                   isinstance(f.default_factory, dataclasses._MISSING_TYPE):  # type: ignore # pylint: disable=protected-access
-                    # raise exception if field has no defaults defined
+                # if the missing key's type is non-optional, raise an exception
+                if not typing_inspect.is_optional_type(f.type):
                     raise DeserializeError(f'Missing input data for mandatory key {f.name}')
 
                 continue

--- a/test/serializer/test_metadata_rw.py
+++ b/test/serializer/test_metadata_rw.py
@@ -1,0 +1,66 @@
+'''
+Tests for the DataclassSerializer when fields have the "rw" metadata property set.
+'''
+from typing import Optional
+
+from dataclasses import dataclass, field
+
+from jira_offline.utils.serializer import DataclassSerializer
+
+
+@dataclass
+class Test(DataclassSerializer):
+    r: Optional[str]    = field(default=None, metadata={'rw': 'r'})
+    w: Optional[str]    = field(default=None, metadata={'rw': 'w'})
+    rw: Optional[str]   = field(default=None, metadata={'rw': 'rw'})
+    none: Optional[str] = field(default=None, metadata={'rw': ''})
+
+
+def test_r_field_metadata_field_succeeds_deserialize():
+    """
+    Test fields with metadata rw=r SUCCEEDs deserialize
+    """
+    assert Test.deserialize({'r': 'teststring'}).r == 'teststring'
+
+def test_w_field_metadata_field_fails_deserialize():
+    """
+    Test fields with metadata rw=w FAILs deserialize
+    """
+    assert Test.deserialize({'w': 'teststring'}).w is None
+
+def test_rw_field_metadata_field_succeeds_deserialize():
+    """
+    Test fields with metadata rw=rw SUCCEEDs deserialize
+    """
+    assert Test.deserialize({'rw': 'teststring'}).rw == 'teststring'
+
+def test_none_field_metadata_field_fails_deserialize():
+    """
+    Test fields with metadata rw=none FAILs deserialize
+    """
+    assert Test.deserialize({'none': 'teststring'}).none is None
+
+
+def test_r_field_metadata_field_fails_serialize():
+    """
+    Test fields with metadata rw=r SUCCEEDs deserialize
+    """
+    assert 'r' not in Test(r='teststring').serialize()
+
+def test_w_field_metadata_field_succeeds_serialize():
+    """
+    Test fields with metadata rw=w SUCCEEDs serialize
+    """
+    assert Test(w='teststring').serialize()['w'] == 'teststring'
+
+def test_rw_field_metadata_field_fails_serialize():
+    """
+    Test fields with metadata rw=rw SUCCEEDs deserialize
+    """
+    assert Test(rw='teststring').serialize()['rw'] == 'teststring'
+
+def test_none_field_metadata_field_succeeds_serialize():
+    """
+    Test fields with metadata rw=none SUCCEEDs serialize
+    """
+    assert 'none' not in Test(none='teststring').serialize()

--- a/test/serializer/test_optional.py
+++ b/test/serializer/test_optional.py
@@ -1,0 +1,36 @@
+'''
+Tests for the DataclassSerializer special-case where Optional fields must have a default configured
+'''
+from dataclasses import dataclass, field
+from typing import Optional
+
+import pytest
+
+from jira_offline.utils.serializer import DeserializeError, DataclassSerializer
+
+
+@dataclass
+class TestOptionalWithDefault(DataclassSerializer):
+    # GOOD
+    s: Optional[str] = field(default='s')
+
+@dataclass
+class TestOptionalWithoutDefault(DataclassSerializer):
+    # BAD
+    s: Optional[str]
+
+
+def test_optional_field_with_default_deserializes():
+    """
+    Test an Optional field with a configured default deserializes successfully
+    """
+    obj = TestOptionalWithDefault.deserialize({'s': 'teststring'})
+    assert isinstance(obj.s, str)
+    assert obj.s == 'teststring'
+
+def test_optional_field_without_default_deserialize_raises_exception():
+    """
+    Test an Optional field WITHOUT a configured default raises an exception on deserialize
+    """
+    with pytest.raises(DeserializeError):
+        TestOptionalWithoutDefault.deserialize({'s': 'teststring'})

--- a/test/serializer/test_property.py
+++ b/test/serializer/test_property.py
@@ -1,3 +1,7 @@
+'''
+Tests for the DataclassSerializer fields which are implemented as a private class attribute, with a
+getter/setter @property exposing the field.
+'''
 from dataclasses import dataclass, field
 from typing import Optional
 

--- a/test/serializer/test_typed_dict.py
+++ b/test/serializer/test_typed_dict.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Optional, Dict
 
 import pytest
 
@@ -16,7 +16,7 @@ class Test(DataclassSerializer):
 
 @dataclass
 class TestWithDefaults(DataclassSerializer):
-    d: Dict[str, Nested] = field(default_factory=dict)
+    d: Optional[Dict[str, Nested]] = field(default_factory=dict)
 
 
 def test_typed_dict_deserialize():

--- a/test/serializer/test_typed_set.py
+++ b/test/serializer/test_typed_set.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Set
+from typing import Optional, Set
 
 import pytest
 
@@ -12,7 +12,7 @@ class Test(DataclassSerializer):
 
 @dataclass
 class TestWithDefaults(DataclassSerializer):
-    s: Set[str] = field(default_factory=set)
+    s: Optional[Set[str]] = field(default_factory=set)
 
 
 def test_typed_set_deserialize():


### PR DESCRIPTION
A bunch of improvements to the dataclass serializer:

- Ignore `repr=False` fields during serialize and deserialize
- A better handling for mandatory fields (non-`Optional` types)
- Some basic refactoring/renaming/comment improvements