### PR TITLE
Support for typing.List in DataclassSerializer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+---
 version: '3'
 
 services:

--- a/jira_offline/utils/__init__.py
+++ b/jira_offline/utils/__init__.py
@@ -10,7 +10,7 @@ import arrow
 import click
 from tabulate import tabulate
 
-from jira_offline.utils.serializer import get_enum, get_type_class
+from jira_offline.utils.serializer import get_enum, get_base_type
 
 
 @functools.lru_cache()
@@ -66,7 +66,7 @@ def render_field(cls: type, field_name: str, value: Any, title_prefix: str=None,
         title = f'{title_prefix}{title}'
 
     # determine the origin type for this field (thus handling Optional[type])
-    type_ = get_type_class(get_field_by_name(cls, field_name).type)
+    type_ = get_base_type(get_field_by_name(cls, field_name).type)
 
     # format value as dataclass.field type
     value = render_value(value, type_)

--- a/jira_offline/utils/serializer.py
+++ b/jira_offline/utils/serializer.py
@@ -11,9 +11,9 @@ import typing_inspect
 from jira_offline.exceptions import DeserializeError
 
 
-def get_type_class(type_):
+def get_base_type(type_):
     '''
-    Attempt to get the origin class for a type. Handle Optional and generic types.
+    Attempt to get the base or "origin type" for a type. Handle Optional and generic types.
 
     For example,
         typing.Dict base type is dict
@@ -40,7 +40,7 @@ def get_enum(type_: type) -> Optional[type]:
     '''
     Return enum if type_ is a subclass of enum.Enum. Handle typing.Optional.
     '''
-    type_ = get_type_class(type_)
+    type_ = get_base_type(type_)
     if issubclass(type_, enum.Enum):
         return type_
     return None
@@ -201,7 +201,7 @@ class DataclassSerializer:
                 raise DeserializeError(f'Fatal TypeError for key {f.name} ({e})')
 
             # extract the base type from a typing type (eg. typing.Dict becomes dict)
-            base_type = get_type_class(f.type)
+            base_type = get_base_type(f.type)
 
             # special handling for generic Dict
             if base_type is dict:
@@ -243,7 +243,7 @@ class DataclassSerializer:
             raw_value = self.__dict__.get(f.name)
 
             # extract the base type from a typing type (eg. typing.Dict becomes dict)
-            base_type = get_type_class(f.type)
+            base_type = get_base_type(f.type)
 
             # special handling for generic Dict
             if base_type is dict:

--- a/jira_offline/utils/serializer.py
+++ b/jira_offline/utils/serializer.py
@@ -299,7 +299,10 @@ class DataclassSerializer:
             except TypeError as e:
                 raise DeserializeError(f'Fatal TypeError for key {f.name} ({e})')
 
-            data[f.name] = deserialize_value(f.type, raw_value)
+            try:
+                data[f.name] = deserialize_value(f.type, raw_value)
+            except DeserializeError as e:
+                raise DeserializeError(f'{e} in field {f.name}')
 
         return cls(**data)  # type: ignore
 

--- a/jira_offline/utils/serializer.py
+++ b/jira_offline/utils/serializer.py
@@ -15,14 +15,18 @@ def unwrap_optional_type(type_):
     '''
     Unwrap typing.Optional around a type.
 
+    The parameter evaluate=True _must_ be passed to `get_args` to ensure consistent behaviour across
+    pythons:
+        https://github.com/ilevkivskyi/typing_inspect/blob/master/typing_inspect.py#L410
+
     For example,
         typing.Optional[str] is str
         typing.Optional[dict] is dict
     '''
     if typing_inspect.is_optional_type(type_):
-        # typing.Optional can also be written as typing.Union[type, None]
+        # typing.Optional is sugar for representing an optional type as typing.Union[type, None]
         # this means the base type is the first arg in the return from typing_inspect.get_args()
-        type_ = typing_inspect.get_args(type_)[0]
+        type_ = typing_inspect.get_args(type_, evaluate=True)[0]
 
     return type_
 

--- a/test/serializer/test_dict.py
+++ b/test/serializer/test_dict.py
@@ -1,0 +1,82 @@
+from dataclasses import dataclass
+
+import pytest
+
+from jira_offline.utils.serializer import DeserializeError, DataclassSerializer
+
+
+@dataclass
+class Test(DataclassSerializer):
+    d: dict
+
+
+def test_dict_deserialize():
+    """
+    Test dict deserializes
+    """
+    obj = Test.deserialize({
+        'd': {
+            'key1': {'x': 'abc'},
+            'key2': {'x': 'def'},
+        }
+    })
+    assert isinstance(obj.d, dict)
+    assert obj.d == {
+        'key1': {'x': 'abc'},
+        'key2': {'x': 'def'},
+    }
+
+def test_dict_deserialize_roundrip():
+    """
+    Test dict deserializes/serializes in a loss-less roundrip
+    """
+    json = Test.deserialize({
+        'd': {
+            'key1': {'x': 'abc'},
+            'key2': {'x': 'def'},
+        }
+    }).serialize()
+    assert json['d'] == {
+        'key1': {'x': 'abc'},
+        'key2': {'x': 'def'},
+    }
+
+def test_dict_serialize():
+    """
+    Test dict serializes
+    """
+    json = Test(
+        d={
+            'key1': {'x': 'abc'},
+            'key2': {'x': 'def'},
+        }
+    ).serialize()
+    assert json['d'] == {
+        'key1': {'x': 'abc'},
+        'key2': {'x': 'def'},
+    }
+
+def test_dict_serialize_roundrip():
+    """
+    Test dict serializes/deserializes in a loss-less roundrip
+    """
+    obj = Test.deserialize(
+        Test(
+            d={
+                'key1': {'x': 'abc'},
+                'key2': {'x': 'def'},
+            }
+        ).serialize()
+    )
+    assert isinstance(obj.d, dict)
+    assert obj.d == {
+        'key1': {'x': 'abc'},
+        'key2': {'x': 'def'},
+    }
+
+def test_dict_bad_deserialize():
+    '''
+    Test bad dict deserialize raises exception
+    '''
+    with pytest.raises(DeserializeError):
+        Test.deserialize({'d': 'Egx'})

--- a/test/serializer/test_get_base_type.py
+++ b/test/serializer/test_get_base_type.py
@@ -25,3 +25,16 @@ def test__get_base_type__str(type_):
 def test__get_base_type__dict(type_):
     '''Ensure the base type is dict'''
     assert get_base_type(type_) is dict
+
+
+@pytest.mark.parametrize('type_', [
+    list,
+    typing.List,
+    typing.List[str],
+    typing.Optional[list],
+    typing.Optional[typing.List],
+    typing.Optional[typing.List[str]],
+])
+def test__get_base_type__list(type_):
+    '''Ensure the base type is list'''
+    assert get_base_type(type_) is list

--- a/test/serializer/test_get_base_type.py
+++ b/test/serializer/test_get_base_type.py
@@ -19,6 +19,8 @@ def test__get_base_type__str(type_):
     typing.Dict,
     typing.Dict[str, str],
     typing.Optional[dict],
+    typing.Optional[typing.Dict],
+    typing.Optional[typing.Dict[str, str]],
 ])
 def test__get_base_type__dict(type_):
     '''Ensure the base type is dict'''

--- a/test/serializer/test_get_base_type.py
+++ b/test/serializer/test_get_base_type.py
@@ -1,0 +1,25 @@
+import typing
+
+import pytest
+
+from jira_offline.utils.serializer import get_base_type
+
+
+@pytest.mark.parametrize('type_', [
+    str,
+    typing.Optional[str],
+])
+def test__get_base_type__str(type_):
+    '''Ensure the base type is str'''
+    assert get_base_type(type_) is str
+
+
+@pytest.mark.parametrize('type_', [
+    dict,
+    typing.Dict,
+    typing.Dict[str, str],
+    typing.Optional[dict],
+])
+def test__get_base_type__dict(type_):
+    '''Ensure the base type is dict'''
+    assert get_base_type(type_) is dict

--- a/test/serializer/test_list.py
+++ b/test/serializer/test_list.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+
+import pytest
+
+from jira_offline.utils.serializer import DeserializeError, DataclassSerializer
+
+
+@dataclass
+class Test(DataclassSerializer):
+    l: list
+
+
+def test_list_deserialize():
+    """
+    Test list deserializes
+    """
+    obj = Test.deserialize({
+        'l': ['abc', 'def']
+    })
+    assert isinstance(obj.l, list)
+    assert obj.l == ['abc', 'def']
+
+def test_list_deserialize_roundrip():
+    """
+    Test list deserializes/serializes in a loss-less roundrip
+    """
+    json = Test.deserialize({
+        'l': ['abc', 'def']
+    }).serialize()
+    assert json['l'] == ['abc', 'def']
+
+def test_list_serialize():
+    """
+    Test list serializes
+    """
+    json = Test(
+        l=['abc', 'def']
+    ).serialize()
+    assert json['l'] == ['abc', 'def']
+
+def test_list_serialize_roundrip():
+    """
+    Test list serializes/deserializes in a loss-less roundrip
+    """
+    obj = Test.deserialize(
+        Test(
+            l=['abc', 'def']
+        ).serialize()
+    )
+    assert isinstance(obj.l, list)
+    assert obj.l == ['abc', 'def']
+
+def test_list_bad_deserialize():
+    '''
+    Test bad list deserialize raises exception
+    '''
+    with pytest.raises(DeserializeError):
+        Test.deserialize({'l': 'Egx'})

--- a/test/serializer/test_typed_list.py
+++ b/test/serializer/test_typed_list.py
@@ -1,0 +1,98 @@
+from dataclasses import dataclass, field
+from typing import Optional, List
+
+import pytest
+
+from jira_offline.utils.serializer import DeserializeError, DataclassSerializer
+
+
+@dataclass
+class Test(DataclassSerializer):
+    l: List[str]
+
+@dataclass
+class TestWithDefaults(DataclassSerializer):
+    l: Optional[List[str]] = field(default_factory=list)
+
+
+FIXTURES=[Test, TestWithDefaults]
+
+
+@pytest.mark.parametrize('class_', FIXTURES)
+def test_typed_list_deserialize(class_):
+    """
+    Test typing.List deserializes
+    """
+    obj = class_.deserialize({
+        'l': ['abc', 'def']
+    })
+    assert isinstance(obj.l, list)
+    assert obj.l == ['abc', 'def']
+
+
+@pytest.mark.parametrize('class_', FIXTURES)
+def test_typed_list_deserialize_roundrip(class_):
+    """
+    Test typing.List deserializes/serializes in a loss-less roundrip
+    """
+    json = class_.deserialize({
+        'l': ['abc', 'def']
+    }).serialize()
+    assert json['l'] == ['abc', 'def']
+
+
+@pytest.mark.parametrize('class_', FIXTURES)
+def test_typed_list_serialize(class_):
+    """
+    Test typing.List serializes
+    """
+    json = class_(
+        l=['abc', 'def']
+    ).serialize()
+    assert json['l'] == ['abc', 'def']
+
+
+@pytest.mark.parametrize('class_', FIXTURES)
+def test_typed_list_serialize_roundrip(class_):
+    """
+    Test typing.List serializes/deserializes in a loss-less roundrip
+    """
+    obj = class_.deserialize(
+        class_(
+            l=['abc', 'def']
+        ).serialize()
+    )
+    assert isinstance(obj.l, list)
+    assert obj.l == ['abc', 'def']
+
+
+BAD_INPUT = [
+    {'l': 'key1'},
+    {'l': {'key1': 'abc'}},
+    {'l': 123},
+]
+
+@pytest.mark.parametrize('class_,bad_input', [
+    (f, i) for f in FIXTURES for i in BAD_INPUT
+])
+def test_typed_list_bad_deserialize(class_, bad_input):
+    '''
+    Test bad typing.List deserialize raises exception (exception raised when passed value is not a list)
+    '''
+    with pytest.raises(DeserializeError):
+        class_.deserialize(bad_input)
+
+
+def test_typed_list_with_defaults_deserializes_empty():
+    """
+    Test typing.List with a default configured deserializes
+    """
+    obj = TestWithDefaults.deserialize({})
+    assert isinstance(obj.l, list)
+
+def test_typed_list_without_defaults_fails_deserialize_empty():
+    """
+    Test typing.List WITHOUT a default configured FAILS to deserialize
+    """
+    with pytest.raises(DeserializeError):
+        Test.deserialize({})

--- a/test/serializer/test_typed_set.py
+++ b/test/serializer/test_typed_set.py
@@ -15,62 +15,84 @@ class TestWithDefaults(DataclassSerializer):
     s: Optional[Set[str]] = field(default_factory=set)
 
 
-def test_typed_set_deserialize():
+FIXTURES=[Test, TestWithDefaults]
+
+
+@pytest.mark.parametrize('class_', FIXTURES)
+def test_typed_set_deserialize(class_):
     """
     Test typing.set deserializes
     """
-    obj = Test.deserialize({
+    obj = class_.deserialize({
         's': ['abc', 'def']
     })
     assert isinstance(obj.s, set)
     assert obj.s == {'abc', 'def'}
 
-def test_typed_set_with_defaults_deserialize():
-    """
-    Test typing.set with field(default_factory=set) deserializes
-    """
-    obj = TestWithDefaults.deserialize({})
-    assert isinstance(obj.s, set)
 
-def test_typed_set_deserialize_roundrip():
+@pytest.mark.parametrize('class_', FIXTURES)
+def test_typed_set_deserialize_roundrip(class_):
     """
     Test typing.set deserializes/serializes in a loss-less roundrip
     """
-    json = Test.deserialize({
+    json = class_.deserialize({
         's': ['abc', 'def']
     }).serialize()
     assert json['s'] == ['abc', 'def']
 
-def test_typed_set_serialize():
+
+@pytest.mark.parametrize('class_', FIXTURES)
+def test_typed_set_serialize(class_):
     """
     Test typing.set serializes
     """
-    json = Test(
+    json = class_(
         s={'abc', 'def'}
     ).serialize()
     assert json['s'] == ['abc', 'def']
 
-def test_typed_set_serialize_roundrip():
+
+@pytest.mark.parametrize('class_', FIXTURES)
+def test_typed_set_serialize_roundrip(class_):
     """
     Test typing.set serializes/deserializes in a loss-less roundrip
     """
-    obj = Test.deserialize(
-        Test(
+    obj = class_.deserialize(
+        class_(
             s={'abc', 'def'}
         ).serialize()
     )
     assert isinstance(obj.s, set)
     assert obj.s == {'abc', 'def'}
 
-@pytest.mark.parametrize('bad_input', [
-    {},
+
+BAD_INPUT = [
     {'s': 'key1'},
     {'s': {'key1': 'abc'}},
     {'s': 123},
+]
+
+@pytest.mark.parametrize('class_,bad_input', [
+    (f, i) for f in FIXTURES for i in BAD_INPUT
 ])
-def test_typed_set_bad_deserialize(bad_input):
+def test_typed_set_bad_deserialize(class_, bad_input):
     '''
     Test bad typing.set deserialize raises exception (exception raised when passed value is not a list)
     '''
     with pytest.raises(DeserializeError):
-        Test.deserialize(bad_input)
+        class_.deserialize(bad_input)
+
+
+def test_typed_set_with_defaults_deserializes_empty():
+    """
+    Test typing.Set with a default configured deserializes
+    """
+    obj = TestWithDefaults.deserialize({})
+    assert isinstance(obj.s, set)
+
+def test_typed_set_without_defaults_fails_deserialize_empty():
+    """
+    Test typing.Set WITHOUT a default configured FAILS to deserialize
+    """
+    with pytest.raises(DeserializeError):
+        Test.deserialize({})


### PR DESCRIPTION
.. And a bunch of plumbing and refactoring to make that possible. 

* Resolved one of the code smells in the `serializer` module (b375dab)
* Much better test coverage for `typing.Dict` and `typing.Set` (87abcc2, 2221bd6)
* The headline feature (1e43399)