### PR TITLE
Improve mypy support

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,2 @@
 [MESSAGES CONTROL]
-disable=invalid-name, missing-docstring, bad-whitespace, import-error, no-else-return, line-too-long, too-many-arguments, too-many-locals, too-few-public-methods, inconsistent-return-statements, wrong-import-order
+disable=bad-whitespace, import-error, invalid-name, missing-docstring, no-else-return, no-member, line-too-long, too-many-arguments, too-many-locals, too-few-public-methods, inconsistent-return-statements, wrong-import-order

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ lint:
 
 .PHONY: typecheck
 typecheck:
-	docker-compose run --rm test --mypy --mypy-ignore-missing-imports jira_offline/
+	docker-compose run --rm test --mypy jira_offline/
 
 
 .PHONY: package

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - /tmp:/tmp
       - ./pytest.ini:/app/pytest.ini
       - ./.pylintrc:/app/.pylintrc
+      - ./mypy.ini:/app/mypy.ini:ro
 
   jira:
     image: mafrosis/jira

--- a/jira_offline/create.py
+++ b/jira_offline/create.py
@@ -123,7 +123,7 @@ def create_issue(jira: 'Jira', project: ProjectMeta, issuetype: str, summary: st
     jira[new_issue.key] = new_issue
     jira.write_issues()
 
-    return jira[new_issue.key]
+    return new_issue
 
 
 def set_field_on_issue(issue: Issue, field_name: str, value: str):

--- a/jira_offline/create.py
+++ b/jira_offline/create.py
@@ -126,7 +126,7 @@ def create_issue(jira: 'Jira', project: ProjectMeta, issuetype: str, summary: st
     return new_issue
 
 
-def set_field_on_issue(issue: Issue, field_name: str, value: str):
+def set_field_on_issue(issue: Issue, field_name: str, value: Optional[str]):
     '''
     Use DataclassSerializer.deserialize_value to convert from string to the corrent type, and then
     set the single attribute on the target Issue object.

--- a/jira_offline/create.py
+++ b/jira_offline/create.py
@@ -111,11 +111,11 @@ def create_issue(jira: 'Jira', project: ProjectMeta, issuetype: str, summary: st
     for field_name, value in kwargs.items():
         set_field_on_issue(new_issue, field_name, value)
 
-    if check_summary_exists(jira, new_issue.project, new_issue.summary):  # pylint: disable=no-member
+    if check_summary_exists(jira, new_issue.project, new_issue.summary):
         raise SummaryAlreadyExists
 
-    if new_issue.epic_ref:  # pylint: disable=no-member
-        matched_epic = find_epic_by_reference(jira, new_issue.epic_ref)  # pylint: disable=no-member
+    if new_issue.epic_ref:
+        matched_epic = find_epic_by_reference(jira, new_issue.epic_ref)
         new_issue.epic_ref = matched_epic.key
 
     # use a temporary Issue.key until Jira server creates the actual key at sync-time

--- a/jira_offline/entrypoint.py
+++ b/jira_offline/entrypoint.py
@@ -255,7 +255,7 @@ def cli_pull(ctx, projects: str=None, reset_hard: bool=False):
         if projects:
             reset_warning = '\n'.join(projects_set)  # type: ignore
         else:
-            reset_warning = '\n'.join([p.key for p in jira.config.projects.values()])  # type: ignore
+            reset_warning = '\n'.join([p.key for p in jira.config.projects.values()])
 
         if reset_warning:
             click.confirm(

--- a/jira_offline/main.py
+++ b/jira_offline/main.py
@@ -211,12 +211,12 @@ class Jira(collections.abc.MutableMapping):
                 raise JiraNotConfigured(project.key, project.jira_server, err)
 
         # add to self under the new key
-        self[new_issue.key] = new_issue  # pylint: disable=no-member
+        self[new_issue.key] = new_issue
 
-        if new_issue.issuetype == 'Epic':  # pylint: disable=no-member
+        if new_issue.issuetype == 'Epic':
             # relink any issue linked to this epic to the new Jira-generated key
             for linked_issue in [i for i in self.values() if i.epic_ref == temp_key]:
-                linked_issue.epic_ref = new_issue.key  # pylint: disable=no-member
+                linked_issue.epic_ref = new_issue.key
 
         # remove the placeholder Issue
         del self[temp_key]

--- a/jira_offline/models.py
+++ b/jira_offline/models.py
@@ -9,7 +9,7 @@ import hashlib
 import os
 import pathlib
 import shutil
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, cast, Dict, List, Optional, Set, Tuple
 
 import click
 import dictdiffer
@@ -278,7 +278,7 @@ class Issue(DataclassSerializer):  # pylint: disable=too-many-instance-attribute
             List from dictdiffer.diff for Issue.diff_to_original property
         '''
         # deserialize supplied dict into an Issue object
-        issue = super().deserialize(attrs)
+        issue = cast(Issue, super().deserialize(attrs))
 
         if issue.diff_to_original is None:
             issue.diff_to_original = []

--- a/jira_offline/models.py
+++ b/jira_offline/models.py
@@ -280,14 +280,14 @@ class Issue(DataclassSerializer):  # pylint: disable=too-many-instance-attribute
         # deserialize supplied dict into an Issue object
         issue = super().deserialize(attrs)
 
-        if issue.diff_to_original is None:  # pylint: disable=no-member
+        if issue.diff_to_original is None:
             issue.diff_to_original = []
 
         # if issue exists on Jira server (see `exists` property above)
         if bool(attrs.get('id')):
             # apply the diff_to_original patch to the serialized version of the issue, which
             # recreates the issue dict as last seen on the Jira server
-            issue.original = dictdiffer.patch(issue.diff_to_original, issue.serialize())  # pylint: disable=no-member
+            issue.original = dictdiffer.patch(issue.diff_to_original, issue.serialize())
 
         # store reference to Jira project this Issue belongs to
         issue.project_ref = project_ref

--- a/jira_offline/sync.py
+++ b/jira_offline/sync.py
@@ -215,7 +215,7 @@ def merge_issues(base_issue: Issue, updated_issue: Issue) -> IssueUpdate:
     return update_object
 
 
-def build_update(base_issue: Issue, updated_issue: Issue) -> IssueUpdate:
+def build_update(base_issue: Issue, updated_issue: Optional[Issue]) -> IssueUpdate:
     '''
     Generate an object representing an Issue update.
 

--- a/jira_offline/utils/__init__.py
+++ b/jira_offline/utils/__init__.py
@@ -100,11 +100,11 @@ def render_value(value: Any, type_: Optional[type]=None) -> str:
         dt = arrow.get(value)
         return f'{dt.humanize()} [{dt.format()}]'
     elif get_enum(type_):
-        return value.value
+        return str(value.value)
     elif value and type_ is str and len(value) > 100:
         return '\n'.join(textwrap.wrap(value, width=100))
     else:
-        return value
+        return str(value)
 
 
 @contextlib.contextmanager

--- a/jira_offline/utils/api.py
+++ b/jira_offline/utils/api.py
@@ -64,7 +64,7 @@ def _request(method: str, project: ProjectMeta, path: str, params: Optional[Dict
         raise JiraUnavailable(e)
 
     try:
-        return resp.json()
+        return resp.json()  # type: ignore[no-any-return]
     except json.decoder.JSONDecodeError:
         return {}
 

--- a/jira_offline/utils/serializer.py
+++ b/jira_offline/utils/serializer.py
@@ -94,7 +94,7 @@ def deserialize_value(type_, value: Any, tz=None) -> Any:  # pylint: disable=too
     base_type = get_base_type(type_)
 
     if dataclasses.is_dataclass(base_type):
-        return base_type.deserialize(value)  # type: ignore
+        return base_type.deserialize(value)
 
     elif base_type is decimal.Decimal:
         try:
@@ -144,7 +144,7 @@ def deserialize_value(type_, value: Any, tz=None) -> Any:  # pylint: disable=too
             return {
                 deserialize_value(generic_key_type, item_key, tz=tz):
                     deserialize_value(generic_value_type, item_value, tz=tz)
-                for item_key, item_value in value.items()  # type: ignore
+                for item_key, item_value in value.items()
             }
         except AttributeError:
             raise DeserializeError(f'Failed serializing "{value}" to {base_type}')
@@ -234,7 +234,7 @@ def serialize_value(type_, value: Any) -> Any:  # pylint: disable=too-many-retur
         return {
             serialize_value(generic_key_type, item_key):
                 serialize_value(generic_value_type, item_value)
-            for item_key, item_value in value.items()  # type: ignore
+            for item_key, item_value in value.items()
         }
 
     elif base_type is list and typing_inspect.is_generic_type(type_):

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,6 +5,7 @@ warn_unused_configs = True
 # warning on various typing smells
 warn_redundant_casts = True
 warn_unused_ignores = True
+warn_return_any = True
 
 # suppress error messages about imports that cannot be resolved
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,10 @@
+[mypy]
+# warn on misspelled section names in config
+warn_unused_configs = True
+
+# suppress error messages about imports that cannot be resolved
+ignore_missing_imports = True
+
+# show error codes in error messages
+show_error_codes = True
+show_error_context = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,6 +6,7 @@ warn_unused_configs = True
 warn_redundant_casts = True
 warn_unused_ignores = True
 warn_return_any = True
+warn_unreachable = True
 
 # suppress error messages about imports that cannot be resolved
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,6 +2,10 @@
 # warn on misspelled section names in config
 warn_unused_configs = True
 
+# warning on various typing smells
+warn_redundant_casts = True
+warn_unused_ignores = True
+
 # suppress error messages about imports that cannot be resolved
 ignore_missing_imports = True
 

--- a/test/.pylintrc
+++ b/test/.pylintrc
@@ -1,2 +1,2 @@
 [MESSAGES CONTROL]
-disable=duplicate-code, line-too-long, invalid-name, bad-whitespace, import-error, missing-module-docstring, protected-access, unused-argument, too-many-arguments, missing-class-docstring, redefined-outer-name
+disable=bad-whitespace, duplicate-code, invalid-name, import-error, line-too-long, missing-class-docstring, missing-module-docstring, no-member, protected-access, redefined-outer-name, too-many-arguments, unused-argument

--- a/test/sync/test_build_update.py
+++ b/test/sync/test_build_update.py
@@ -18,7 +18,7 @@ def test_build_update__ignores_readonly_fields():
     assert update_obj.modified == {'assignee'}
     assert not update_obj.conflicts
     assert update_obj.merged_issue.assignee == 'hoganp'
-    assert update_obj.merged_issue.updated == base_issue.updated  # pylint: disable=no-member
+    assert update_obj.merged_issue.updated == base_issue.updated
 
 
 def test_build_update__base_unmodified_and_updated_modified():
@@ -88,7 +88,7 @@ def test_build_update__base_modified_on_set_type_and_updated_modified_set_type_r
     base_issue = Issue.deserialize(ISSUE_1_WITH_FIXVERSIONS_DIFF)
     # pass a conflicting modified Issue object (on fixVersions set)
     updated_issue = Issue.deserialize(ISSUE_1)
-    updated_issue.fixVersions.add('0.3')  # pylint: disable=no-member
+    updated_issue.fixVersions.add('0.3')
 
     update_obj = build_update(base_issue, updated_issue)
 

--- a/test/sync/test_editor_parser.py
+++ b/test/sync/test_editor_parser.py
@@ -15,7 +15,7 @@ def test_parse_editor_result__handles_str_type():
         IssueUpdate(merged_issue=Issue.deserialize(ISSUE_1), conflicts={'assignee'}),
         editor_result_raw,
     )
-    assert edited_issue.assignee == 'hoganp'  # pylint: disable=no-member
+    assert edited_issue.assignee == 'hoganp'
 
 
 def test_parse_editor_result__handles_str_type_over_100_chars():
@@ -30,7 +30,7 @@ def test_parse_editor_result__handles_str_type_over_100_chars():
         IssueUpdate(merged_issue=Issue.deserialize(ISSUE_1), conflicts={'description'}),
         editor_result_raw,
     )
-    assert edited_issue.description == str('This is a story or issue '*5).strip()  # pylint: disable=no-member
+    assert edited_issue.description == str('This is a story or issue '*5).strip()
 
 
 def test_parse_editor_result__parses_summary_str():
@@ -43,7 +43,7 @@ def test_parse_editor_result__parses_summary_str():
         IssueUpdate(merged_issue=Issue.deserialize(ISSUE_1), conflicts={'summary'}),
         editor_result_raw,
     )
-    assert edited_issue.summary == 'This is the story summary'  # pylint: disable=no-member
+    assert edited_issue.summary == 'This is the story summary'
 
 
 def test_parse_editor_result__handles_set_type():
@@ -58,7 +58,7 @@ def test_parse_editor_result__handles_set_type():
         IssueUpdate(merged_issue=Issue.deserialize(ISSUE_1), conflicts={'fixVersions'}),
         editor_result_raw,
     )
-    assert edited_issue.fixVersions == {'0.1', '0.3'}  # pylint: disable=no-member
+    assert edited_issue.fixVersions == {'0.1', '0.3'}
 
 
 def test_parse_editor_result__handles_int_type():
@@ -73,4 +73,4 @@ def test_parse_editor_result__handles_int_type():
         IssueUpdate(merged_issue=Issue.deserialize(ISSUE_1), conflicts={'estimate'}),
         editor_result_raw,
     )
-    assert edited_issue.estimate == 99  # pylint: disable=no-member
+    assert edited_issue.estimate == 99

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -29,7 +29,7 @@ def test_issue_model__status_property_ok_when_writing_valid_value(project):
 
     # set the status to a valid value
     issue1.status = 'Done'
-    assert issue1._status == 'Done'  # pylint: disable=no-member
+    assert issue1._status == 'Done'
 
 
 def test_issue_model__priority_property_fails_when_writing_invalid_value(project):
@@ -58,7 +58,7 @@ def test_issue_model__priority_property_ok_when_writing_valid_value(project):
 
     # set the priority to a valid value
     issue1.priority = 'High'
-    assert issue1._priority == 'High'  # pylint: disable=no-member
+    assert issue1._priority == 'High'
 
 
 def test_issue_model__when_project_has_no_priorities_priority_property_fails_when_writing_any_value(project):


### PR DESCRIPTION
Key fix in this P/R is the use of `disable=no-member` application wide, and the `cast()` wrapped in `Issue.deserialize`.

Pylint doesn't need to check types (or members of types), because mypy does that, and now we don't have the two type-checking systems disagreeing with each other.