### PR TITLE
Auth retry decorator

### DIFF
--- a/jira_offline/config.py
+++ b/jira_offline/config.py
@@ -42,6 +42,10 @@ def load_config():
         # ensure schema is set to latest
         config.schema_version = AppConfig().schema_version
 
+        # ensure each ProjectMeta instance has a reference to the AppConfig instance
+        for p in config.projects.values():
+            p.config = config
+
     if not config:
         config = AppConfig()
 

--- a/jira_offline/jira.py
+++ b/jira_offline/jira.py
@@ -15,6 +15,7 @@ from jira_offline.exceptions import (EpicNotFound, EstimateFieldUnavailable, Jir
 from jira_offline.models import AppConfig, CustomFields, IssueFilter, Issue, IssueType, ProjectMeta
 from jira_offline.utils.api import get as api_get, post as api_post, put as api_put
 from jira_offline.utils.convert import jiraapi_object_to_issue
+from jira_offline.utils.decorators import auth_retry
 
 
 logger = logging.getLogger('jira')
@@ -139,6 +140,7 @@ class Jira(collections.abc.MutableMapping):
             writer.write_all(issues_json)
 
 
+    @auth_retry()
     def get_project_meta(self, project: ProjectMeta):  # pylint: disable=no-self-use
         '''
         Load additional Jira project meta data from Jira's createmeta API

--- a/jira_offline/models.py
+++ b/jira_offline/models.py
@@ -78,6 +78,9 @@ class ProjectMeta(DataclassSerializer):  # pylint: disable=too-many-instance-att
     ca_cert: Optional[str] = field(default=None)
     timezone: Optional[str] = field(default=None)
 
+    # reference to parent AppConfig class
+    config: Optional['AppConfig'] = field(default=None, metadata={'rw': ''})
+
     @property
     def jira_server(self):
         return f'{self.protocol}://{self.hostname}'

--- a/jira_offline/utils/api.py
+++ b/jira_offline/utils/api.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional
 
 import requests
 
-from jira_offline.exceptions import JiraApiError, JiraUnavailable
+from jira_offline.exceptions import FailedAuthError, JiraApiError, JiraUnavailable
 from jira_offline.models import ProjectMeta
 
 
@@ -50,6 +50,9 @@ def _request(method: str, project: ProjectMeta, path: str, params: Optional[Dict
         resp.raise_for_status()
 
     except requests.exceptions.HTTPError:
+        if resp.status_code in (401, 403):
+            raise FailedAuthError
+
         if resp.status_code >= 400:
             message = ''
             try:

--- a/jira_offline/utils/decorators.py
+++ b/jira_offline/utils/decorators.py
@@ -1,0 +1,31 @@
+import functools
+
+from jira_offline.auth import get_user_creds
+from jira_offline.exceptions import FailedAuthError
+from jira_offline.models import ProjectMeta
+
+
+def auth_retry():
+    '''
+    This decorator will prompt for a username/password on the CLI, should the wrapped function raise
+    a `FailedAuthError`.
+
+    The first argument to the wrapped function *must* be an instance of ProjectMeta, so that the new
+    auth credentials can be written to the config JSON.
+    '''
+    def decorator(f):
+        @functools.wraps(f)
+        def wrapped(*args, **kwargs):
+            if not isinstance(args[1], ProjectMeta):
+                raise TypeError('First argument to auth_retry decorator must be ProjectMeta instance')
+
+            try:
+                return f(*args, **kwargs)
+            except FailedAuthError as e:
+                print(e)
+                # prompt for new credentials
+                get_user_creds(args[1])
+                args[1].config.write_to_disk()
+                return f(*args, **kwargs)
+        return wrapped
+    return decorator

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -52,6 +52,9 @@ def mock_jira_core(mock_load_config, project):
     '''
     jira = Jira()
     jira.config = AppConfig(projects={project.id: project})
+    # ensure each ProjectMeta instance has a reference to the AppConfig instance
+    # in normal operation, this is done in `load_config` in config.py, and so applies to all projects
+    project.config = jira.config
     jira.config.write_to_disk = mock.Mock()
     return jira
 


### PR DESCRIPTION
Currently a failed login offers no way to reset the password. Indeed there is also no "password reset" command on the CLI!

This P/R adds the `@auth_retry` decorator which can be applied to any function/method whose first argument is an instance of `ProjectMeta`.