### PR TITLE
--remove-* params & --filter on edit

### DIFF
--- a/jira_offline/cli/main.py
+++ b/jira_offline/cli/main.py
@@ -19,7 +19,8 @@ from jira_offline.cli.params import filter_option, force_option, global_options
 from jira_offline.cli.project import cli_project_list
 from jira_offline.config import get_default_user_config_filepath
 from jira_offline.config.user_config import write_default_user_config
-from jira_offline.create import create_issue, import_csv, import_jsonlines, patch_issue_from_dict
+from jira_offline.create import create_issue, import_csv, import_jsonlines
+from jira_offline.edit import patch_issue_from_dict
 from jira_offline.exceptions import (BadProjectMetaUri, EditorFieldParseFailed, EditorNoChanges,
                                      FailedPullingProjectMeta, JiraApiError, NoInputDuringImport)
 from jira_offline.jira import jira

--- a/jira_offline/cli/main.py
+++ b/jira_offline/cli/main.py
@@ -26,8 +26,8 @@ from jira_offline.jira import jira
 from jira_offline.models import Issue, ProjectMeta
 from jira_offline.sync import pull_issues, pull_single_project, push_issues
 from jira_offline.utils import find_project
-from jira_offline.utils.cli import (CustomfieldsAsOptions, parse_editor_result, prepare_df,
-                                    print_diff, print_list)
+from jira_offline.utils.cli import (CustomfieldsAsOptions, EditClickCommand, parse_editor_result,
+                                    prepare_df, print_diff, print_list)
 
 
 logger = logging.getLogger('jira')
@@ -382,7 +382,7 @@ def cli_new(_, projectkey: str, issuetype: str, summary: str, as_json: bool=Fals
     click.echo(output)
 
 
-@click.command(name='edit', cls=CustomfieldsAsOptions, no_args_is_help=True)
+@click.command(name='edit', cls=EditClickCommand, no_args_is_help=True)
 @click.argument('key')
 @click.option('--json', 'as_json', '-j', is_flag=True, help='Print output in JSON format')
 @click.option('--editor', is_flag=True, help='Free edit all issue fields in your shell editor')

--- a/jira_offline/create.py
+++ b/jira_offline/create.py
@@ -1,62 +1,24 @@
 '''
-Module for functions related to Issue creation, editing and bulk import.
+Module for functions related to Issue creation and import.
 '''
-import dataclasses
-import functools
 import json
 import io
 import logging
-from typing import cast, Hashable, IO, List, Optional, Set, Tuple
+from typing import IO, List, Optional, Tuple
 import uuid
 
 import pandas as pd
 from tqdm import tqdm
 
-from jira_offline.exceptions import (EpicNotFound, EpicSearchStrUsedMoreThanOnce,
-                                     FieldNotOnModelClass, ImportFailed, InvalidIssueType,
-                                     NoInputDuringImport, ProjectNotConfigured)
+from jira_offline.edit import patch_issue_from_dict
+from jira_offline.exceptions import (ImportFailed, InvalidIssueType, NoInputDuringImport,
+                                     ProjectNotConfigured)
 from jira_offline.jira import jira
-from jira_offline.models import CustomFields, Issue, ProjectMeta
-from jira_offline.utils import (critical_logger, deserialize_single_issue_field, find_project,
-                                get_field_by_name)
-from jira_offline.utils.serializer import DeserializeError, istype
+from jira_offline.models import Issue, ProjectMeta
+from jira_offline.utils import critical_logger, find_project
 
 
 logger = logging.getLogger('jira')
-
-
-def find_linked_issue_by_ref(search_str: str) -> Issue:
-    '''
-    Find a linked issue by search string.
-
-    This will attempt find a linked issue by searching in this order:
-       1. Issue.key
-       2. Issue.epic_name
-       3. Issue.summary
-
-    Params:
-       search_str:  String to search for
-    Returns:
-       Matched Issue object
-    '''
-    # First attempt to match the search string to an existing issue key
-    matched: Optional[Issue] = jira.get(search_str)
-    if matched:
-        return matched
-
-    keys = list(jira.df[jira.df.epic_name == search_str].index)
-    if len(keys) == 1:
-        return cast(Issue, jira[keys[0]])
-    if len(keys) > 0:
-        raise EpicSearchStrUsedMoreThanOnce(search_str)
-
-    keys = list(jira.df[jira.df.summary.str.match(f'(.*){search_str}(.*)')].index)
-    if len(keys) == 1:
-        return cast(Issue, jira[keys[0]])
-    if len(keys) > 0:
-        raise EpicSearchStrUsedMoreThanOnce(search_str)
-
-    raise EpicNotFound(search_str)
 
 
 def create_issue(project: ProjectMeta, issuetype: str, summary: str, strict: bool=False, **kwargs) -> Issue:
@@ -260,154 +222,3 @@ def _import_new_issue(attrs: dict, strict: bool=False) -> Issue:
         if 'project' not in attrs:
             raise ImportFailed(f'No project reference on new {issuetype} "{summary}"')
         raise ImportFailed(f'Unknown project ref {attrs["project"]} for new issue')
-
-
-@functools.lru_cache()
-def get_unused_customfields(project: ProjectMeta) -> Set[str]:
-    if project.customfields:
-        return {
-            f.name for f in dataclasses.fields(CustomFields)
-            if f.name not in dict(project.customfields.items())
-        }
-    else:
-        return set()
-
-
-def patch_issue_from_dict(issue: Issue, attrs: dict, strict: bool=False) -> bool:
-    '''
-    Patch attributes on an Issue from the passed dict
-
-    Params:
-        issue:   Issue object to patch with k:v attributes
-        attrs:   Dictionary containing k:v issue attributes
-        strict:  When true, raise exceptions on error instead of just logging
-    '''
-    patched = False
-    remove = False
-
-    # Ignore unused customfields
-    unused_customfields = get_unused_customfields(issue.project)
-
-    for field_name, value in attrs.items():
-        if value is None:
-            # Skip nulls in patch dict
-            continue
-
-        if field_name == 'epic_name' and issue.issuetype != 'Epic':
-            # Epic Name field is only valid for Epics
-            logger.debug('%s: Skipped field "epic_name" as it\'s only applicable to epics', issue.key)
-            continue
-
-        if field_name in unused_customfields:
-            # Ignore unused customfields
-            logger.debug('%s: Skipped field "%s" as not in use on this project', issue.key, field_name)
-            continue
-
-        if field_name.startswith('remove_'):
-            # Special case for removing a value from a set/list type field
-            field_name = field_name[7:]
-            remove = True
-
-        try:
-            # Extract type from Issue dataclass field
-            f = get_field_by_name(Issue, field_name)
-
-            # Cast for mypy as get_base_type uses @functools.lru_cache
-            typ = cast(Hashable, f.type)
-
-            if f.metadata.get('readonly'):
-                # Do not modify readonly fields
-                logger.debug('%s: Skipped readonly field "%s"', issue.key, field_name)
-                continue
-
-            # Link an issue to epic/parent, if link field is supplied
-            if field_name in ('epic_link', 'parent_link'):
-                try:
-                    matched = find_linked_issue_by_ref(attrs[field_name])
-                    setattr(issue, field_name, matched.key)
-                except EpicNotFound as e:
-                    logger.debug('%s: Skipped linking to unknown epic %s', issue.key, field_name)
-                    if strict:
-                        raise e
-                except EpicSearchStrUsedMoreThanOnce as e:
-                    logger.debug('%s: %s', issue.key, e)
-                    if strict:
-                        raise e
-
-                patched = True
-                continue
-
-            # Reset before edit means a field can only be modified once until it's sync'd with Jira.
-            # This setting only makes sense for sets/lists; and is primarily a hack in place for
-            # Issue.sprint which is a set, but can only be updated as a single value via the API.
-            if f.metadata.get('reset_before_edit'):
-                original_value = deserialize_single_issue_field(
-                    field_name, issue.original.get(field_name), issue.project
-                )
-                setattr(issue, field_name, original_value)
-
-            try:
-                value = deserialize_single_issue_field(field_name, value, issue.project)
-
-            except DeserializeError as e:
-                logger.debug('%s: %s', issue.key, e)
-                if strict:
-                    raise e
-
-            if istype(typ, set):
-                # Special case where a string is passed for a set field
-                if getattr(issue, field_name) is None:
-                    setattr(issue, field_name, set())
-
-                if not isinstance(value, (set, list)):
-                    value = [value]
-
-                if remove is True:
-                    setattr(issue, field_name, getattr(issue, field_name) ^ set(value))
-                else:
-                    setattr(issue, field_name, getattr(issue, field_name) | set(value))
-
-            elif istype(typ, list):
-                # Special case where a string is passed for a list field
-                if getattr(issue, field_name) is None:
-                    setattr(issue, field_name, [])
-
-                if remove is True:
-                    # Remove all instances of value from the list
-                    setattr(issue, field_name, [x for x in getattr(issue, field_name) if x != value])
-                else:
-                    getattr(issue, field_name).append(value)
-
-            elif istype(typ, str) and value == '':
-                # When setting an Issue attribute to empty string, map it to None
-                setattr(issue, field_name, None)
-            else:
-                setattr(issue, field_name, value)
-
-            patched = True
-
-        except FieldNotOnModelClass:
-            # FieldNotOnModelClass raised by `get_field_by_name` means this field is not a core Issue
-            # attribute; and is possibly an extended customfield.
-            if field_name.startswith('extended.'):
-                field_name = field_name[9:]
-
-            # Verify this is really a configured customfield before continuing
-            if issue.project.customfields and issue.project.customfields.extended is not None:
-                if field_name not in issue.project.customfields.extended:
-                    logger.debug('%s: Skipped unrecognised customfield "%s"', issue.key, field_name)
-                    continue
-
-            # Dynamic user-defined customfields are stored in issue.extended dict and are always
-            # str, so no type conversion is necessary.
-            if not issue.extended:
-                issue.extended = dict()
-
-            issue.extended[field_name] = value
-            patched = True
-
-    # Commit issue object changes back into the DataFrame
-    if patched:
-        issue.commit()
-
-    return patched

--- a/jira_offline/edit.py
+++ b/jira_offline/edit.py
@@ -1,0 +1,202 @@
+'''
+Module for functions related to Issue editing.
+'''
+import dataclasses
+import functools
+import logging
+from typing import cast, Hashable, Optional, Set
+
+from jira_offline.exceptions import (EpicNotFound, EpicSearchStrUsedMoreThanOnce,
+                                     FieldNotOnModelClass)
+from jira_offline.jira import jira
+from jira_offline.models import CustomFields, Issue, ProjectMeta
+from jira_offline.utils import deserialize_single_issue_field, get_field_by_name
+from jira_offline.utils.serializer import DeserializeError, istype
+
+
+logger = logging.getLogger('jira')
+
+
+def find_linked_issue_by_ref(search_str: str) -> Issue:
+    '''
+    Find a linked issue by search string.
+
+    This will attempt find a linked issue by searching in this order:
+       1. Issue.key
+       2. Issue.epic_name
+       3. Issue.summary
+
+    Params:
+       search_str:  String to search for
+    Returns:
+       Matched Issue object
+    '''
+    # First attempt to match the search string to an existing issue key
+    matched: Optional[Issue] = jira.get(search_str)
+    if matched:
+        return matched
+
+    keys = list(jira.df[jira.df.epic_name == search_str].index)
+    if len(keys) == 1:
+        return cast(Issue, jira[keys[0]])
+    if len(keys) > 0:
+        raise EpicSearchStrUsedMoreThanOnce(search_str)
+
+    keys = list(jira.df[jira.df.summary.str.match(f'(.*){search_str}(.*)')].index)
+    if len(keys) == 1:
+        return cast(Issue, jira[keys[0]])
+    if len(keys) > 0:
+        raise EpicSearchStrUsedMoreThanOnce(search_str)
+
+    raise EpicNotFound(search_str)
+
+
+@functools.lru_cache()
+def get_unused_customfields(project: ProjectMeta) -> Set[str]:
+    if project.customfields:
+        return {
+            f.name for f in dataclasses.fields(CustomFields)
+            if f.name not in dict(project.customfields.items())
+        }
+    else:
+        return set()
+
+
+def patch_issue_from_dict(issue: Issue, attrs: dict, strict: bool=False) -> bool:
+    '''
+    Patch attributes on an Issue from the passed dict
+
+    Params:
+        issue:   Issue object to patch with k:v attributes
+        attrs:   Dictionary containing k:v issue attributes
+        strict:  When true, raise exceptions on error instead of just logging
+    '''
+    patched = False
+    remove = False
+
+    # Ignore unused customfields
+    unused_customfields = get_unused_customfields(issue.project)
+
+    for field_name, value in attrs.items():
+        if value is None:
+            # Skip nulls in patch dict
+            continue
+
+        if field_name == 'epic_name' and issue.issuetype != 'Epic':
+            # Epic Name field is only valid for Epics
+            logger.debug('%s: Skipped field "epic_name" as it\'s only applicable to epics', issue.key)
+            continue
+
+        if field_name in unused_customfields:
+            # Ignore unused customfields
+            logger.debug('%s: Skipped field "%s" as not in use on this project', issue.key, field_name)
+            continue
+
+        if field_name.startswith('remove_'):
+            # Special case for removing a value from a set/list type field
+            field_name = field_name[7:]
+            remove = True
+
+        try:
+            # Extract type from Issue dataclass field
+            f = get_field_by_name(Issue, field_name)
+
+            # Cast for mypy as get_base_type uses @functools.lru_cache
+            typ = cast(Hashable, f.type)
+
+            if f.metadata.get('readonly'):
+                # Do not modify readonly fields
+                logger.debug('%s: Skipped readonly field "%s"', issue.key, field_name)
+                continue
+
+            # Link an issue to epic/parent, if link field is supplied
+            if field_name in ('epic_link', 'parent_link'):
+                try:
+                    matched = find_linked_issue_by_ref(attrs[field_name])
+                    setattr(issue, field_name, matched.key)
+                except EpicNotFound as e:
+                    logger.debug('%s: Skipped linking to unknown epic %s', issue.key, field_name)
+                    if strict:
+                        raise e
+                except EpicSearchStrUsedMoreThanOnce as e:
+                    logger.debug('%s: %s', issue.key, e)
+                    if strict:
+                        raise e
+
+                patched = True
+                continue
+
+            # Reset before edit means a field can only be modified once until it's sync'd with Jira.
+            # This setting only makes sense for sets/lists; and is primarily a hack in place for
+            # Issue.sprint which is a set, but can only be updated as a single value via the API.
+            if f.metadata.get('reset_before_edit'):
+                original_value = deserialize_single_issue_field(
+                    field_name, issue.original.get(field_name), issue.project
+                )
+                setattr(issue, field_name, original_value)
+
+            try:
+                value = deserialize_single_issue_field(field_name, value, issue.project)
+
+            except DeserializeError as e:
+                logger.debug('%s: %s', issue.key, e)
+                if strict:
+                    raise e
+
+            if istype(typ, set):
+                # Special case where a string is passed for a set field
+                if getattr(issue, field_name) is None:
+                    setattr(issue, field_name, set())
+
+                if not isinstance(value, (set, list)):
+                    value = [value]
+
+                if remove is True:
+                    setattr(issue, field_name, getattr(issue, field_name) ^ set(value))
+                else:
+                    setattr(issue, field_name, getattr(issue, field_name) | set(value))
+
+            elif istype(typ, list):
+                # Special case where a string is passed for a list field
+                if getattr(issue, field_name) is None:
+                    setattr(issue, field_name, [])
+
+                if remove is True:
+                    # Remove all instances of value from the list
+                    setattr(issue, field_name, [x for x in getattr(issue, field_name) if x != value])
+                else:
+                    getattr(issue, field_name).append(value)
+
+            elif istype(typ, str) and value == '':
+                # When setting an Issue attribute to empty string, map it to None
+                setattr(issue, field_name, None)
+            else:
+                setattr(issue, field_name, value)
+
+            patched = True
+
+        except FieldNotOnModelClass:
+            # FieldNotOnModelClass raised by `get_field_by_name` means this field is not a core Issue
+            # attribute; and is possibly an extended customfield.
+            if field_name.startswith('extended.'):
+                field_name = field_name[9:]
+
+            # Verify this is really a configured customfield before continuing
+            if issue.project.customfields and issue.project.customfields.extended is not None:
+                if field_name not in issue.project.customfields.extended:
+                    logger.debug('%s: Skipped unrecognised customfield "%s"', issue.key, field_name)
+                    continue
+
+            # Dynamic user-defined customfields are stored in issue.extended dict and are always
+            # str, so no type conversion is necessary.
+            if not issue.extended:
+                issue.extended = dict()
+
+            issue.extended[field_name] = value
+            patched = True
+
+    # Commit issue object changes back into the DataFrame
+    if patched:
+        issue.commit()
+
+    return patched

--- a/jira_offline/exceptions.py
+++ b/jira_offline/exceptions.py
@@ -273,7 +273,14 @@ class FilterMozParseFailed(BaseAppException):
     'Invalid SQL WHERE clause passed as filter string'
 
 class FilterQueryParseFailed(BaseAppException):
-    'Failed processing filter string'
+    'Failed processing filter string: {}'
+
+    def __init__(self, excp=None):
+        self.message = str(excp) or ''
+        super().__init__(self.message)
+
+    def __str__(self):
+        return self.__doc__.format(self.message)
 
 class FilterQueryEscapingError(FilterQueryParseFailed):
     'Ensure your whole filter string is not double-escaped'

--- a/jira_offline/exceptions.py
+++ b/jira_offline/exceptions.py
@@ -341,3 +341,6 @@ class FieldNotOnModelClass(BaseAppException):
 
     def __str__(self):
         return self.__doc__.format(self.field)
+
+class MustFilterOnProjectWithSprint(BaseAppException):
+    'You must filter on project when also filtering on sprint'

--- a/jira_offline/exceptions.py
+++ b/jira_offline/exceptions.py
@@ -328,10 +328,6 @@ class InvalidLsFieldInConfig(BaseAppException):
         return self.__doc__.format(self.field)
 
 
-class BadParamsPassedToValidCustomfield(BaseAppException):
-    'ValidCustomfield constructor must be passed `key` or `projectkey`'
-
-
 class FieldNotOnModelClass(BaseAppException):
     '{} does not exist!'
 

--- a/jira_offline/exceptions.py
+++ b/jira_offline/exceptions.py
@@ -334,19 +334,3 @@ class FieldNotOnModelClass(BaseAppException):
 
     def __str__(self):
         return self.__doc__.format(self.field)
-
-
-class UnknownSprintError(BaseAppException):
-    'Sprint "{}" is not valid. It could be closed, or it could not exist on {}.'
-
-    def __init__(self, project_key, sprint):
-        self.project_key = project_key
-        self.sprint = sprint
-        super().__init__()
-
-    def __str__(self):
-        return self.__doc__.format(self.sprint, self.project_key)
-
-
-class ProjectHasNoSprints(BaseAppException):
-    'Raised by some sprint helpers for projects which do not use sprints'

--- a/jira_offline/models.py
+++ b/jira_offline/models.py
@@ -354,9 +354,9 @@ class Issue(DataclassSerializer):
     creator: Optional[str] = field(default=None, metadata={'readonly': True})
     description: Optional[str] = field(default=None)
     id: Optional[int] = field(default=None, metadata={'readonly': True})
-    fix_versions: Optional[set] = field(default_factory=set, metadata={'friendly': 'Fix Version'})
-    components: Optional[set] = field(default_factory=set)
-    labels: Optional[set] = field(default_factory=set)
+    fix_versions: Optional[Set[str]] = field(default_factory=set, metadata={'friendly': 'Fix Version'})  # type: ignore[assignment]
+    components: Optional[Set[str]] = field(default_factory=set)  # type: ignore[assignment]
+    labels: Optional[Set[str]] = field(default_factory=set)  # type: ignore[assignment]
     priority: Optional[str] = field(default=None)
     reporter: Optional[str] = field(default=None)
     status: Optional[str] = field(default=None)

--- a/jira_offline/models.py
+++ b/jira_offline/models.py
@@ -392,7 +392,7 @@ class Issue(DataclassSerializer):
     )
 
     # Patch of current Issue to dict last seen on Jira server
-    modified: Optional[list] = field(default=None)
+    modified: Optional[list] = field(default=None, metadata={'readonly': True})
 
     # List of transitions available for this issue
     transitions: Optional[Dict[str, int]] = field(default=None, metadata={'readonly': True})

--- a/jira_offline/models.py
+++ b/jira_offline/models.py
@@ -499,6 +499,8 @@ class Issue(DataclassSerializer):
         '''
         # deserialize supplied dict into an Issue object
         # use `cast` to cover the mypy typecheck errors the arise from polymorphism
+        attrs['project_id'] = project.id
+
         return cast(
             Issue,
             super().deserialize(

--- a/jira_offline/models.py
+++ b/jira_offline/models.py
@@ -10,7 +10,7 @@ import hashlib
 import os
 import pathlib
 import shutil
-from typing import Any, cast, Dict, Generator, Iterator, List, Optional, Set, Tuple
+from typing import Any, cast, Dict, Iterable, List, Optional, Set, Tuple
 from urllib.parse import urlparse
 
 import click
@@ -70,7 +70,7 @@ class CustomFields(DataclassSerializer):
     extended: Optional[Dict[str, str]] = field(default_factory=dict)  # type: ignore[assignment]
 
 
-    def items(self) -> Iterator:
+    def items(self) -> Iterable:
         'Iterate the customfields set for the associated project, plus user-defined ones in self.extended'
         attrs = {k:v for k,v in asdict(self).items() if v}
         if self.extended:
@@ -600,7 +600,7 @@ class Issue(DataclassSerializer):
 
         def iter_optionals():
             'Iterate the optional attributes of this issue'
-            def iter_fields(field_name, customfield_value) -> Generator[Tuple, None, None]:
+            def iter_fields(field_name, customfield_value) -> Iterable[Tuple]:
                 # Always display modified fields
                 if modified_fields and field_name in modified_fields:
                     for x in fmt(field_name):

--- a/jira_offline/sql_filter.py
+++ b/jira_offline/sql_filter.py
@@ -93,7 +93,7 @@ class IssueFilter:
 
     def _build_mask(self, df: pd.DataFrame, filter_: dict) -> pd.Series:
         '''
-        Recurse the WHERE part of the result from `mozparse`, and build a logical Series mask to
+        Recurse the WHERE part of the result from `mozparse`, and build a logical pd.Series mask to
         filter the central DataFrame
 
         Params:
@@ -122,16 +122,16 @@ class IssueFilter:
                 )
             elif operator_ == 'lt':
                 # field less than 00:00:00 on value date
-                return dt
+                return operator.lt(df[column], dt)
             elif operator_ == 'gt':
                 # field greater than 23:59:59 on value date
-                return midnight(dt)
+                return operator.gt(df[column], midnight(dt))
             elif operator_ == 'gte':
                 # field greater than or equal to 00:00:00 on value date
-                return dt
+                return operator.ge(df[column], dt)
             elif operator_ == 'lte':
                 # field less than or equal to 23:59:59 on value date
-                return midnight(dt)
+                return operator.le(df[column], midnight(dt))
             elif operator_ == 'neq':
                 # field less than 00:00:00 on value date, OR greater than 23:59:59 on value date
                 return operator.or_(
@@ -150,7 +150,7 @@ class IssueFilter:
             # `field_` is the Issue attribute to filter on
             # `value` is the value to compare against
 
-            # Recursive filter builing for AND and OR
+            # Recursive filter building for AND and OR
             if operator_ == 'and':
                 return operator.and_(*[self._build_mask(df, cnd) for cnd in conditions])
             elif operator_ == 'or':
@@ -188,9 +188,9 @@ class IssueFilter:
                     dt = arrow.get(value).replace(tzinfo=self.tz).datetime
 
                     if (dt.hour, dt.minute, dt.second) == (0, 0, 0):
-                        value = handle_date_without_time(operator_, dt)
-                        if isinstance(value, pd.Series):
-                            return value
+                        # Handle the special case where a date is passed as a filter without the
+                        # time component.
+                        return handle_date_without_time(operator_, dt)
                     else:
                         value = dt
 

--- a/jira_offline/sync.py
+++ b/jira_offline/sync.py
@@ -17,8 +17,8 @@ from tqdm import tqdm
 
 from jira_offline.exceptions import (EditorFieldParseFailed, FailedPullingIssues,
                                      FailedPullingProjectMeta, JiraApiError, JiraUnavailable)
+from jira_offline.edit import patch_issue_from_dict
 from jira_offline.jira import jira
-from jira_offline.create import patch_issue_from_dict
 from jira_offline.models import Issue, IssueUpdate, ProjectMeta
 from jira_offline.utils import critical_logger
 from jira_offline.utils.api import get as api_get

--- a/jira_offline/utils/__init__.py
+++ b/jira_offline/utils/__init__.py
@@ -224,14 +224,18 @@ def render_value(value: Any, type_: Optional[type]=None) -> str:
         return str(value)
 
 
-def deserialize_single_issue_field(field_name: str, value: Optional[Any], project: Optional['ProjectMeta']=None) -> Any:
+def deserialize_single_issue_field(
+        field_name: str, value: Optional[Any], project: Optional['ProjectMeta']=None,
+        type_override: Optional[type]=None
+    ) -> Any:
     '''
     Use DataclassSerializer.deserialize_value to convert from string to the correct type.
 
     Params:
-        field_name:  Name of the field Issue dataclass
-        value:       Value to deserialize to field_name's type
-        project:     Properties of the project this issue belongs to
+        field_name:     Name of the field Issue dataclass
+        value:          Value to deserialize to field_name's type
+        project:        Properties of the project this issue belongs to
+        type_override:  Deserialize to a different type than specified on the Issue model field
     '''
     if value is None:
         return
@@ -240,7 +244,10 @@ def deserialize_single_issue_field(field_name: str, value: Optional[Any], projec
         # late import to avoid circular dependency
         from jira_offline.models import Issue  # pylint: disable=import-outside-toplevel
 
-        typ = get_field_by_name(Issue, field_name).type
+        if type_override:
+            typ = type_override
+        else:
+            typ = get_field_by_name(Issue, field_name).type
 
         if not project:
             return deserialize_value(typ, value, tz=get_localzone())

--- a/jira_offline/utils/cli.py
+++ b/jira_offline/utils/cli.py
@@ -384,3 +384,29 @@ class CustomfieldsAsOptions(click.Command):
             )
 
         super().__init__(*args, **kwargs)
+
+
+class RemoveableIssueFieldOptions(click.Command):
+    '''
+    Add list/set type Issue fields as --remove-* optional CLI parameters
+    '''
+    def __init__(self, *args, **kwargs):
+        for f in iter_issue_fields_by_type(set, list):
+            if f.metadata.get('readonly'):
+                continue
+
+            field_name = f.name.replace('_', '-')
+
+            # Extract help text if defined on Issue class field
+            help_text = f'Remove given {field_name} from an issue'
+
+            kwargs['params'].insert(
+                len(kwargs['params'])-3,  # insert above global_options
+                ValidCustomfield([f'--remove-{field_name}'], help=help_text),
+            )
+
+        super().__init__(*args, **kwargs)
+
+
+class EditClickCommand(CustomfieldsAsOptions, RemoveableIssueFieldOptions):
+    pass

--- a/jira_offline/utils/convert.py
+++ b/jira_offline/utils/convert.py
@@ -5,7 +5,6 @@ _to_ an object good for an API post.
 import logging
 from typing import Generator, List, Optional, Union, Set, TYPE_CHECKING
 
-from jira_offline.exceptions import ProjectHasNoSprints, UnknownSprintError
 from jira_offline.utils import get_field_by_name
 
 if TYPE_CHECKING:
@@ -178,25 +177,3 @@ def sprint_objects_to_names(sprints: Set['Sprint']) -> Generator[str, None, None
     '''
     for sprint in sorted(sprints):
         yield sprint.name
-
-
-def sprint_name_to_sprint_object(project: 'ProjectMeta', sprint_name: str) -> 'Sprint':
-    '''
-    Utility function to return a Sprint object, when passed a sprint name.
-
-    Params:
-        project_id:   Internal project ID
-        sprint_name:  Text name of a sprint
-    '''
-    if not project.sprints:
-        raise ProjectHasNoSprints
-
-    try:
-        return next(x for x in project.sprints.values() if x.name == sprint_name)
-    except StopIteration as e:
-        raise UnknownSprintError(project.key, sprint_name) from e
-
-
-def parse_list(project: 'ProjectMeta', value: str) -> List[str]:  # pylint: disable=unused-argument
-    'Parse a comma-separated list string into a list of strings'
-    return [f.strip() for f in value.split(',')]

--- a/jira_offline/utils/convert.py
+++ b/jira_offline/utils/convert.py
@@ -3,7 +3,7 @@ Two util functions for converting _from_ an API response to an Issue, and for co
 _to_ an object good for an API post.
 '''
 import logging
-from typing import Generator, List, Optional, Union, Set, TYPE_CHECKING
+from typing import Iterable, List, Optional, Union, Set, TYPE_CHECKING
 
 from jira_offline.utils import get_field_by_name
 
@@ -175,7 +175,7 @@ def parse_sprint(val: Union[str, dict]) -> Optional[List[dict]]:
     return None
 
 
-def sprint_objects_to_names(sprints: Set['Sprint']) -> Generator[str, None, None]:
+def sprint_objects_to_names(sprints: Set['Sprint']) -> Iterable[str]:
     '''
     Utility function to convert a set of sprint objects into a set of sprint names. This is used
     when rendering a set of Sprint objects in the CLI, and is mapped via dataclass.field metadata in

--- a/jira_offline/utils/serializer.py
+++ b/jira_offline/utils/serializer.py
@@ -250,6 +250,9 @@ def deserialize_value(type_, value: Any, tz: datetime.tzinfo, project: Optional[
             raise DeserializeError('Only booleans can be deserialized to boolean type')
 
     else:
+        if base_type is str:
+            value = str(value)
+
         # handle enum
         enum_type = get_enum(base_type)
         if enum_type:
@@ -259,7 +262,6 @@ def deserialize_value(type_, value: Any, tz: datetime.tzinfo, project: Optional[
             except ValueError:
                 raise DeserializeError(f'Failed deserializing {value} to {type_}')
 
-    # no deserialize necessary
     return value
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -14,7 +14,7 @@ import requests
 from tzlocal import get_localzone
 
 from jira_offline.jira import Jira
-from jira_offline.create import get_unused_customfields
+from jira_offline.edit import get_unused_customfields
 from jira_offline.models import AppConfig, CustomFields, IssueType, ProjectMeta, Sprint
 from jira_offline.utils.cli import _get_issue, _get_project
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -15,7 +15,7 @@ from tzlocal import get_localzone
 
 from jira_offline.jira import Jira
 from jira_offline.create import get_unused_customfields
-from jira_offline.models import AppConfig, CustomFields, IssueType, ProjectMeta
+from jira_offline.models import AppConfig, CustomFields, IssueType, ProjectMeta, Sprint
 from jira_offline.utils.cli import _get_issue, _get_project
 
 
@@ -33,6 +33,9 @@ def project():
             epic_name='customfield_10200',
             sprint='customfield_10300',
         ),
+        sprints={
+            1: Sprint(id=1, name='Sprint 1', active=True),
+        },
         priorities=['High', 'Low'],
         issuetypes={'Story': IssueType(name='Story', statuses=['Backlog', 'Done'])},
     )

--- a/test/models/test_issue.py
+++ b/test/models/test_issue.py
@@ -6,7 +6,7 @@ from unittest import mock
 from conftest import not_raises
 from fixtures import ISSUE_1, ISSUE_NEW
 from helpers import compare_issue_helper, modified_issue_helper
-from jira_offline.models import Issue, ProjectMeta, Sprint
+from jira_offline.models import Issue, Sprint
 
 
 def test_issue_model__modified_is_false_after_constructor(project):
@@ -242,14 +242,10 @@ def test_issue_model__render_returns_optional_fields_only_when_set(project):
     assert output[5] == ('Creator', 'danil1')
 
 
-def test_issue_model__render_returns_sprint_names():
+def test_issue_model__render_returns_sprint_names(project):
     '''
     Validate Issue.render returns the sprint names, and not the stored IDs
     '''
-    project = ProjectMeta(
-        'TEST',
-        sprints={1: Sprint(id=1, name='Sprint 1', active=True)}
-    )
     issue = Issue.deserialize(ISSUE_1, project)
 
     # Set the sprint field on the issue
@@ -376,7 +372,7 @@ def test_issue_model__render_deserializes_values_in_original(project):
     Validate Issue.render returns added and removed rows, when a field is changed
     '''
     # Create an issue which exists in a sprint
-    with mock.patch.dict(ISSUE_1, {'sprint': [{'id': 1, 'name': 'Sprint 1', 'active': True}]}):
+    with mock.patch.dict(ISSUE_1, {'sprint': 'Sprint 1'}):
         issue = Issue.deserialize(ISSUE_1, project)
 
     # Remove the sprint

--- a/test/sync/test_build_update.py
+++ b/test/sync/test_build_update.py
@@ -362,7 +362,7 @@ def test_build_update__base_modified_and_updated_modified_to_empty_string(projec
     assert update_obj.merged_issue.assignee is None
 
 
-@pytest.mark.parametrize('value_to_append', [0, 2])
+@pytest.mark.parametrize('value_to_append', ['0', '2'])
 def test_build_update__base_unmodified_and_updated_modified_to_append_to_set(project, value_to_append):
     '''
     Ensure an unmodified Issue can have a set field appended when it already has a value.
@@ -373,7 +373,7 @@ def test_build_update__base_unmodified_and_updated_modified_to_append_to_set(pro
     order on the resulting set (https://stackoverflow.com/a/51949325/425050)
     '''
     # Create test fixtures with starting Issue.fix_version == set(1)
-    with mock.patch.dict(ISSUE_1, {'fix_versions': {1}}):
+    with mock.patch.dict(ISSUE_1, {'fix_versions': {'1'}}):
         base_issue = Issue.deserialize(ISSUE_1, project)
         updated_issue = Issue.deserialize(ISSUE_1, project)
 
@@ -384,10 +384,10 @@ def test_build_update__base_unmodified_and_updated_modified_to_append_to_set(pro
 
     assert update_obj.modified == {'fix_versions'}
     assert not update_obj.conflicts
-    assert update_obj.merged_issue.fix_versions == {1, value_to_append}
+    assert update_obj.merged_issue.fix_versions == {'1', value_to_append}
 
 
-@pytest.mark.parametrize('value_to_append', [0, 2])
+@pytest.mark.parametrize('value_to_append', ['0', '2'])
 def test_build_update__base_modified_and_updated_modified_to_append_to_set(project, value_to_append):
     '''
     Ensure an unmodified Issue can have a set field appended when it already has a value.
@@ -398,7 +398,7 @@ def test_build_update__base_modified_and_updated_modified_to_append_to_set(proje
     order on the resulting set (https://stackoverflow.com/a/51949325/425050)
     '''
     # Create test fixtures with starting Issue.fix_version == set(1)
-    with mock.patch.dict(ISSUE_1, {'fix_versions': {1}}):
+    with mock.patch.dict(ISSUE_1, {'fix_versions': {'1'}}):
         base_issue = Issue.deserialize(ISSUE_1, project)
         updated_issue = Issue.deserialize(ISSUE_1, project)
 
@@ -409,4 +409,4 @@ def test_build_update__base_modified_and_updated_modified_to_append_to_set(proje
 
     assert update_obj.modified == {'fix_versions'}
     assert not update_obj.conflicts
-    assert update_obj.merged_issue.fix_versions == {1, value_to_append}
+    assert update_obj.merged_issue.fix_versions == {'1', value_to_append}

--- a/test/test_create.py
+++ b/test/test_create.py
@@ -494,7 +494,7 @@ def test_create__patch_issue_from_dict__uses_reset_before_edit(mock_jira):
     )
 
     # Create an issue which already exists in a sprint
-    with mock.patch.dict(ISSUE_1, {'sprint': [{'id': 1, 'name': 'Sprint 1', 'active': True}]}):
+    with mock.patch.dict(ISSUE_1, {'sprint': 'Sprint 1'}):
         issue = Issue.deserialize(ISSUE_1, project)
 
     issue.commit = mock.Mock()

--- a/test/test_create.py
+++ b/test/test_create.py
@@ -404,6 +404,30 @@ def test_create__patch_issue_from_dict__set_set(mock_jira, project, param):
     assert patched is True
 
 
+@pytest.mark.parametrize('param', [
+    ('bacon'),
+    ('egg,bacon'),
+])
+def test_create__patch_issue_from_dict__remove_from_set(mock_jira, project, param):
+    '''
+    Ensure patch will remove one or many from a set
+    '''
+    with mock.patch.dict(ISSUE_1, {'labels': set(param.split(','))}):
+        issue = Issue.deserialize(ISSUE_1, project)
+
+    issue.commit = mock.Mock()
+
+    assert issue.labels == set(param.split(','))
+
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
+        patched = patch_issue_from_dict(issue, {'remove_labels': param})
+
+    assert issue.labels == set()
+    assert issue.commit.called
+    assert patched is True
+
+
 @pytest.mark.skip(reason='Will succeed when there is a list-type field on Issue class')
 @pytest.mark.parametrize('param', [
     ('bacon'),
@@ -426,6 +450,31 @@ def test_create__patch_issue_from_dict__set_list(mock_jira, project, param):
         patched = patch_issue_from_dict(issue, {'labels': param})
 
     assert issue.labels == ['egg', 'bacon']
+    assert issue.commit.called
+    assert patched is True
+
+
+@pytest.mark.skip(reason='Will succeed when there is a list-type field on Issue class')
+@pytest.mark.parametrize('param', [
+    ('bacon'),
+    ('egg,bacon'),
+])
+def test_create__patch_issue_from_dict__remove_from_list(mock_jira, project, param):
+    '''
+    Ensure patch will remove one or many from a list
+    '''
+    with mock.patch.dict(ISSUE_1, {'labels': param.split(',')}):
+        issue = Issue.deserialize(ISSUE_1, project)
+
+    issue.commit = mock.Mock()
+
+    assert issue.labels == param.split(',')
+
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
+        patched = patch_issue_from_dict(issue, {'remove_labels': param})
+
+    assert issue.labels == []
     assert issue.commit.called
     assert patched is True
 

--- a/test/test_create.py
+++ b/test/test_create.py
@@ -4,11 +4,10 @@ import pytest
 
 from fixtures import EPIC_1, ISSUE_1
 from helpers import compare_issue_helper
-from jira_offline.exceptions import (EpicNotFound, EpicSearchStrUsedMoreThanOnce, ImportFailed,
-                                     InvalidIssueType)
-from jira_offline.create import (create_issue, find_linked_issue_by_ref, import_issue, _import_new_issue,
-                                 _import_modified_issue, patch_issue_from_dict)
-from jira_offline.models import CustomFields, Issue, ProjectMeta, Sprint
+from jira_offline.create import (create_issue, import_issue, _import_new_issue,
+                                 _import_modified_issue)
+from jira_offline.exceptions import ImportFailed, InvalidIssueType
+from jira_offline.models import Issue
 
 
 def test_create__create_issue__loads_issues_when_cache_empty(mock_jira, project):
@@ -29,8 +28,7 @@ def test_create__create_issue__does_not_load_issues_when_cache_full(mock_jira, p
     # add an Issue fixture to the Jira dict
     mock_jira['TEST-72'] = Issue.deserialize(ISSUE_1, project)
 
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
+    with mock.patch('jira_offline.jira.jira', mock_jira):
         create_issue(project, 'Story', 'This is a summary')
 
     assert not mock_jira.load_issues.called
@@ -40,8 +38,7 @@ def test_create__create_issue__raises_on_invalid_issuetype(mock_jira, project):
     '''
     Ensure create_issue() raises an exception on an invalid issuetype
     '''
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
+    with mock.patch('jira_offline.jira.jira', mock_jira):
         with pytest.raises(InvalidIssueType):
             create_issue(project, 'FakeType', 'This is a summary')
 
@@ -50,8 +47,7 @@ def test_create__create_issue__adds_issue_to_dataframe(mock_jira, project):
     '''
     Ensure create_issue() adds the new Issue to the DataFrame
     '''
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
+    with mock.patch('jira_offline.jira.jira', mock_jira):
         offline_issue = create_issue(project, 'Story', 'This is a summary')
 
     assert mock_jira[offline_issue.key]
@@ -61,8 +57,7 @@ def test_create__create_issue__mandatory_fields_are_set_in_new_issue(mock_jira, 
     '''
     Ensure create_issue() sets the mandatory fields passed as args (not kwargs)
     '''
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
+    with mock.patch('jira_offline.jira.jira', mock_jira):
         offline_issue = create_issue(project, 'Story', 'This is a summary')
 
     assert offline_issue.project == project
@@ -86,7 +81,7 @@ def test_create__create_issue__kwargs_are_set_in_new_issue(mock_jira, project):
     # Add an Epic fixture to the Jira dict
     mock_jira['TEST-1'] = Issue.deserialize(EPIC_1, project)
 
-    with mock.patch('jira_offline.create.jira', mock_jira), \
+    with mock.patch('jira_offline.edit.jira', mock_jira), \
             mock.patch('jira_offline.jira.jira', mock_jira):
         offline_issue = create_issue(project, 'Story', 'This is a summary', epic_link='TEST-1')
 
@@ -106,8 +101,7 @@ def test_create__create_issue__kwargs_are_set_in_new_issue_extended(mock_jira, p
     # Add an Epic fixture to the Jira dict
     mock_jira['TEST-1'] = Issue.deserialize(EPIC_1, project)
 
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
+    with mock.patch('jira_offline.jira.jira', mock_jira):
         offline_issue = create_issue(project, 'Story', 'This is a summary', arbitrary_key='arbitrary_value')
 
     assert offline_issue.extended['arbitrary_key'] == 'arbitrary_value'
@@ -128,84 +122,12 @@ def test_create__create_issue__issue_is_mapped_to_existing_epic_summary(mock_jir
     # add an Epic fixture to the Jira dict
     mock_jira['TEST-1'] = Issue.deserialize(EPIC_1, project)
 
-    with mock.patch('jira_offline.create.jira', mock_jira), \
+    with mock.patch('jira_offline.edit.jira', mock_jira), \
             mock.patch('jira_offline.jira.jira', mock_jira):
         new_issue = create_issue(project, 'Story', 'This is summary', epic_link=epic_link_value)
 
     # assert new Issue to linked to the epic
     assert new_issue.epic_link == mock_jira['TEST-1'].key
-
-
-def test_create__find_linked_issue_by_ref__match_by_key(mock_jira, project):
-    '''
-    Ensure `find_linked_issue_by_ref` returns an Issue of epic type when passed the Issue key
-    '''
-    # Add an Epic fixture to the Jira dict
-    mock_jira['TEST-1'] = issue = Issue.deserialize(EPIC_1, project)
-
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        linked_issue = find_linked_issue_by_ref('TEST-1')
-
-    compare_issue_helper(issue, linked_issue)
-
-
-@pytest.mark.parametrize('search_str', [
-    ('This is an epic'),
-    ('is an epic'),
-])
-def test_create__find_linked_issue_by_ref__match_by_summary(mock_jira, project, search_str):
-    '''
-    Ensure `find_linked_issue_by_ref` returns an Issue of epic type when passed a summary
-    '''
-    # Add an Epic fixture to the Jira dict
-    mock_jira['TEST-1'] = issue = Issue.deserialize(EPIC_1, project)
-
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        linked_issue = find_linked_issue_by_ref(search_str)
-
-    compare_issue_helper(issue, linked_issue)
-
-
-def test_create__find_linked_issue_by_ref__match_by_epic_name(mock_jira, project):
-    '''
-    Ensure `find_linked_issue_by_ref` returns an Issue of epic type when passed an epic_name
-    '''
-    # Add an Epic fixture to the Jira dict
-    mock_jira['TEST-1'] = issue = Issue.deserialize(EPIC_1, project)
-
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        linked_issue = find_linked_issue_by_ref('0.1: Epic about a thing')
-
-    compare_issue_helper(issue, linked_issue)
-
-
-def test_create__find_linked_issue_by_ref__raise_on_failed_to_match(mock_jira, project):
-    '''
-    Ensure exception raised when epic not found
-    '''
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        with pytest.raises(EpicNotFound):
-            find_linked_issue_by_ref('fake epic reference')
-
-
-def test_create__find_linked_issue_by_ref__raise_on_duplicate_ref_string(mock_jira, project):
-    '''
-    Ensure exception raised when there are two epics matching the search string
-    '''
-    # Setup two epic fixtures
-    mock_jira['TEST-1'] = Issue.deserialize(EPIC_1, project)
-
-    with mock.patch.dict(EPIC_1, {'key': 'TEST-2'}):
-        mock_jira['TEST-2'] = Issue.deserialize(EPIC_1, project)
-
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        with pytest.raises(EpicSearchStrUsedMoreThanOnce):
-            find_linked_issue_by_ref('This is an epic')
 
 
 @mock.patch('jira_offline.create._import_new_issue')
@@ -243,8 +165,8 @@ def test_create__import_modified_issue__returns_issue_if_mod_made(mock_patch_iss
     mock_patch_issue_from_dict.return_value = True
 
     # import same test JSON twice
-    with mock.patch('jira_offline.jira.jira', mock_jira), \
-            mock.patch('jira_offline.create.jira', mock_jira):
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
         imported_issue = _import_modified_issue({'key': 'TEST-71', 'summary': 'This is the story summary'})
 
     compare_issue_helper(issue, imported_issue)
@@ -261,8 +183,8 @@ def test_create__import_modified_issue__returns_none_if_no_mod_made(mock_patch_i
     mock_patch_issue_from_dict.return_value = False
 
     # import same test JSON twice
-    with mock.patch('jira_offline.jira.jira', mock_jira), \
-            mock.patch('jira_offline.create.jira', mock_jira):
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
         imported_issue = _import_modified_issue({'key': 'TEST-71', 'summary': 'This is the story summary'})
 
     assert imported_issue is None
@@ -304,437 +226,3 @@ def test_create__import_new_issue__raises_on_key_missing(mock_jira, keys):
     with mock.patch('jira_offline.create.jira', mock_jira):
         with pytest.raises(ImportFailed):
             _import_new_issue({k[0]:1 for k in zip(keys)})
-
-
-def test_create__patch_issue_from_dict__set_string_to_value(mock_jira, project):
-    '''
-    Ensure an Issue can have attributes set to a string
-    '''
-    issue = Issue.deserialize(ISSUE_1, project)
-
-    issue.commit = mock.Mock()
-
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        patched = patch_issue_from_dict(issue, {'assignee': 'eggs'})
-
-    assert issue.assignee == 'eggs'
-    assert issue.commit.called
-    assert patched is True
-
-
-def test_create__patch_issue_from_dict__set_string_to_blank(mock_jira, project):
-    '''
-    Ensure an Issue can have attributes set to an empty string and it will result in None
-    '''
-    issue = Issue.deserialize(ISSUE_1, project)
-
-    issue.commit = mock.Mock()
-
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        patched = patch_issue_from_dict(issue, {'assignee': ''})
-
-    assert issue.assignee is None
-    assert issue.commit.called
-    assert patched is True
-
-
-def test_create__patch_issue_from_dict__set_priority(mock_jira, project):
-    '''
-    Ensure an Issue.priority can be set
-    '''
-    issue = Issue.deserialize(ISSUE_1, project)
-
-    issue.commit = mock.Mock()
-
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        patched = patch_issue_from_dict(issue, {'priority': 'Bacon'})
-
-    assert issue.priority == 'Bacon'
-    assert issue.commit.called
-    assert patched is True
-
-
-def test_create__patch_issue_from_dict__skips_readonly_fields(mock_jira, project):
-    '''
-    Ensure readonly fields are skipped during a patch
-    '''
-    issue = Issue.deserialize(ISSUE_1, project)
-
-    issue.commit = mock.Mock()
-
-    assert issue.summary == 'This is the story summary'
-    assert issue.project_id == '99fd9182cfc4c701a8a662f6293f4136201791b4'
-
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        patched = patch_issue_from_dict(issue, {'key': 'TEST-71', 'project_id': 'Bacon', 'summary': 'Egg'})
-
-    # Assert writeable field is modified, but the readonly value is not modified
-    assert issue.summary == 'Egg'
-    assert issue.project_id == '99fd9182cfc4c701a8a662f6293f4136201791b4'
-    assert issue.commit.called
-    assert patched is True
-
-
-@pytest.mark.parametrize('param', [
-    ('bacon'),
-    ('egg,bacon'),
-])
-def test_create__patch_issue_from_dict__set_set(mock_jira, project, param):
-    '''
-    When patching a set, if a set is passed overwrite existing value, if a str is passed append to
-    the existing set
-    '''
-    with mock.patch.dict(ISSUE_1, {'labels': set(['egg'])}):
-        issue = Issue.deserialize(ISSUE_1, project)
-
-    issue.commit = mock.Mock()
-
-    assert issue.labels == {'egg'}
-
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        patched = patch_issue_from_dict(issue, {'labels': param})
-
-    assert issue.labels == {'egg', 'bacon'}
-    assert issue.commit.called
-    assert patched is True
-
-
-@pytest.mark.parametrize('param', [
-    ('bacon'),
-    ('egg,bacon'),
-])
-def test_create__patch_issue_from_dict__remove_from_set(mock_jira, project, param):
-    '''
-    Ensure patch will remove one or many from a set
-    '''
-    with mock.patch.dict(ISSUE_1, {'labels': set(param.split(','))}):
-        issue = Issue.deserialize(ISSUE_1, project)
-
-    issue.commit = mock.Mock()
-
-    assert issue.labels == set(param.split(','))
-
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        patched = patch_issue_from_dict(issue, {'remove_labels': param})
-
-    assert issue.labels == set()
-    assert issue.commit.called
-    assert patched is True
-
-
-@pytest.mark.skip(reason='Will succeed when there is a list-type field on Issue class')
-@pytest.mark.parametrize('param', [
-    ('bacon'),
-    ('egg,bacon'),
-])
-def test_create__patch_issue_from_dict__set_list(mock_jira, project, param):
-    '''
-    When patching a list, if a list is passed, overwrite existing value, if a str is passed append to
-    the existing list
-    '''
-    with mock.patch.dict(ISSUE_1, {'labels': ['egg']}):
-        issue = Issue.deserialize(ISSUE_1, project)
-
-    issue.commit = mock.Mock()
-
-    assert issue.labels == ['egg']
-
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        patched = patch_issue_from_dict(issue, {'labels': param})
-
-    assert issue.labels == ['egg', 'bacon']
-    assert issue.commit.called
-    assert patched is True
-
-
-@pytest.mark.skip(reason='Will succeed when there is a list-type field on Issue class')
-@pytest.mark.parametrize('param', [
-    ('bacon'),
-    ('egg,bacon'),
-])
-def test_create__patch_issue_from_dict__remove_from_list(mock_jira, project, param):
-    '''
-    Ensure patch will remove one or many from a list
-    '''
-    with mock.patch.dict(ISSUE_1, {'labels': param.split(',')}):
-        issue = Issue.deserialize(ISSUE_1, project)
-
-    issue.commit = mock.Mock()
-
-    assert issue.labels == param.split(',')
-
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        patched = patch_issue_from_dict(issue, {'remove_labels': param})
-
-    assert issue.labels == []
-    assert issue.commit.called
-    assert patched is True
-
-
-@pytest.mark.parametrize('customfield_name', [
-    ('arbitrary-user-defined-field'),
-    ('extended.arbitrary-user-defined-field'),
-])
-def test_create__patch_issue_from_dict__set_extended_customfield(mock_jira, customfield_name):
-    '''
-    Ensure user-defined customfield "arbitrary-user-defined-field" can be set
-    '''
-    customfields = CustomFields(
-        extended={'arbitrary-user-defined-field': 'customfield_10111'}
-    )
-    project = ProjectMeta(key='TEST', customfields=customfields)
-
-    issue = Issue.deserialize(ISSUE_1, project)
-
-    issue.commit = mock.Mock()
-
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        patched = patch_issue_from_dict(issue, {customfield_name: 'eggs'})
-
-    assert issue.extended['arbitrary-user-defined-field'] == 'eggs'
-    assert issue.commit.called
-    assert patched is True
-
-
-def test_create__patch_issue_from_dict__ignore_undefined_customfield(mock_jira):
-    '''
-    Ensure arbitrary k:v mappings passed into `patch_issue_from_dict` are only applied as extended
-    customfields if they are user-defined in config.
-    '''
-    customfields = CustomFields(
-        extended={}
-    )
-    project = ProjectMeta(key='TEST', customfields=customfields)
-
-    issue = Issue.deserialize(ISSUE_1, project)
-
-    issue.commit = mock.Mock()
-
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        patched = patch_issue_from_dict(issue, {'arbitrary-user-defined-field': 'eggs'})
-
-    assert issue.extended == {}
-    assert not issue.commit.called
-    assert patched is False
-
-
-def test_create__patch_issue_from_dict__uses_reset_before_edit(mock_jira):
-    '''
-    Ensure that the reset_before_edit metadata field causes a single-field reset before a patch
-    '''
-    project = ProjectMeta(
-        key='TEST',
-        customfields=CustomFields(sprint='customfield_10300'),
-        sprints={
-            1: Sprint(id=1, name='Sprint 1', active=True),
-            2: Sprint(id=2, name='Sprint 2', active=False),
-            3: Sprint(id=3, name='Sprint 3', active=False),
-        },
-    )
-
-    # Create an issue which already exists in a sprint
-    with mock.patch.dict(ISSUE_1, {'sprint': 'Sprint 1'}):
-        issue = Issue.deserialize(ISSUE_1, project)
-
-    issue.commit = mock.Mock()
-
-    # Add the issue to another sprint
-    issue.sprint.add(Sprint(id=2, name='Sprint 2', active=False))
-
-    assert issue.sprint == {
-        Sprint(id=1, name='Sprint 1', active=True),
-        Sprint(id=2, name='Sprint 2', active=False),
-    }
-
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        patched = patch_issue_from_dict(issue, {'sprint': 'Sprint 3'})
-
-    # Ensure the modification of sprint before the patch is reset, leaving just sprint 1 & 3 on the issue
-    assert issue.sprint == {
-        Sprint(id=1, name='Sprint 1', active=True),
-        Sprint(id=3, name='Sprint 3', active=False),
-    }
-    assert issue.commit.called
-    assert patched is True
-
-
-def test_create__patch_issue_from_dict__epic_name_ignored_on_story_issuetype(mock_jira, project):
-    '''
-    Ensure the field Issue.epic_name is only imported which issuetype==Epic
-    '''
-    issue = Issue.deserialize(ISSUE_1, project)
-
-    issue.commit = mock.Mock()
-
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        patched = patch_issue_from_dict(issue, {'epic_name': 'eggs'})
-
-    assert issue.epic_name is None
-    assert not issue.commit.called
-    assert patched is False
-
-
-def test_create__patch_issue_from_dict__epic_name_patched_on_epic_issuetype(mock_jira, project):
-    '''
-    Ensure the field Issue.epic_name is only imported which issuetype==Epic
-    '''
-    issue = Issue.deserialize(EPIC_1, project)
-
-    issue.commit = mock.Mock()
-
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        patched = patch_issue_from_dict(issue, {'epic_name': 'eggs'})
-
-    assert issue.epic_name == 'eggs'
-    assert issue.commit.called
-    assert patched is True
-
-
-def test_create__patch_issue_from_dict__ignores_unused_customfields(mock_jira):
-    '''
-    Ensure the customfields on the Issue object are not set when the customfield IS NOT configured
-    for the project
-    '''
-    project = ProjectMeta(
-        key='TEST',
-        customfields=CustomFields(epic_name='customfield_10100')
-    )
-    with mock.patch.dict(EPIC_1, {'epic_name': None}):
-        issue = Issue.deserialize(EPIC_1, project)
-
-    issue.commit = mock.Mock()
-
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        patched = patch_issue_from_dict(issue, {'epic_name': 'eggs'})
-
-    assert issue.epic_name == 'eggs'
-    assert issue.commit.called
-    assert patched is True
-
-
-def test_create__patch_issue_from_dict__doesnt_ignore_not_unused_customfields(mock_jira):
-    '''
-    Ensure the customfields on the Issue object are set when the customfield IS configured for the
-    project
-    '''
-    project = ProjectMeta(
-        key='TEST',
-        customfields=CustomFields()
-    )
-    with mock.patch.dict(EPIC_1, {'epic_name': None}):
-        issue = Issue.deserialize(EPIC_1, project)
-
-    issue.commit = mock.Mock()
-
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        patched = patch_issue_from_dict(issue, {'epic_name': 'eggs'})
-
-    assert issue.epic_name is None
-    assert not issue.commit.called
-    assert patched is False
-
-
-@pytest.mark.parametrize('field', [
-    ('epic_link'),
-    ('parent_link'),
-])
-@mock.patch('jira_offline.create.find_linked_issue_by_ref')
-def test_create__patch_issue_from_dict__links_issue(mock_find_linked_issue_by_ref, mock_jira, field):
-    '''
-    Ensure the fields Issue.epic_link and Issue.parent_link are set correctly
-    '''
-    project = ProjectMeta(
-        'TEST',
-        customfields=CustomFields(
-            epic_link='customfield_10100',
-            parent_link='customfield_10100'
-        ),
-    )
-    issue = Issue.deserialize(ISSUE_1, project)
-
-    issue.commit = mock.Mock()
-
-    mock_find_linked_issue_by_ref.return_value = linked = Issue.deserialize(EPIC_1, project)
-
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        patched = patch_issue_from_dict(issue, {field: 'eggs'})
-
-    mock_find_linked_issue_by_ref.assert_called_with('eggs')
-    assert getattr(issue, field) == linked.key
-    assert issue.commit.called
-    assert patched is True
-
-
-def test_create__patch_issue_from_dict__idempotent(mock_jira, project):
-    '''
-    Ensure an issue can be patched twice and produces an identical diff
-    '''
-    issue = Issue.deserialize(ISSUE_1, project)
-
-    issue.commit = mock.Mock()
-
-    # import same test JSON twice
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        patched = patch_issue_from_dict(issue, {'key': 'TEST-71', 'assignee': 'hoganp'})
-
-    assert issue.assignee == 'hoganp'
-    assert issue.diff() == [('change', 'assignee', ('hoganp', 'danil1'))]
-    assert issue.commit.called
-    assert patched is True
-
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        patched = patch_issue_from_dict(issue, {'key': 'TEST-71', 'assignee': 'hoganp'})
-
-    assert issue.assignee == 'hoganp'
-    assert issue.diff() == [('change', 'assignee', ('hoganp', 'danil1'))]
-    assert issue.commit.called
-    assert patched is True
-
-
-def test_create__patch_issue_from_dict__raises_exception_when_passed_an_unknown_epic_link(mock_jira, project):
-    '''
-    Ensure an exception is raised in strict mode, when an epic_link is passed which does not match
-    an existing epic
-    '''
-    issue = Issue.deserialize(EPIC_1, project)
-
-    issue.commit = mock.Mock()
-
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        with pytest.raises(EpicNotFound):
-            patch_issue_from_dict(issue, {'epic_link': 'Nothing'}, strict=True)
-
-
-def test_create__patch_issue_from_dict__DOES_NOT_raise_exception_when_passed_a_known_epic_link(mock_jira, project):
-    '''
-    Ensure NO exception is raised in strict mode, when an epic_link is passed which does not match
-    an existing epic
-    '''
-    issue = Issue.deserialize(EPIC_1, project)
-
-    issue.commit = mock.Mock()
-
-    with mock.patch('jira_offline.create.jira', mock_jira), \
-            mock.patch('jira_offline.jira.jira', mock_jira):
-        patched = patch_issue_from_dict(issue, {'epic_link': 'Nothing'})
-
-    assert patched is True

--- a/test/test_edit.py
+++ b/test/test_edit.py
@@ -1,0 +1,497 @@
+from unittest import mock
+
+import pytest
+
+from fixtures import EPIC_1, ISSUE_1
+from helpers import compare_issue_helper
+from jira_offline.edit import find_linked_issue_by_ref, patch_issue_from_dict
+from jira_offline.exceptions import EpicNotFound, EpicSearchStrUsedMoreThanOnce
+from jira_offline.models import CustomFields, Issue, ProjectMeta, Sprint
+
+
+def test_create__find_linked_issue_by_ref__match_by_key(mock_jira, project):
+    '''
+    Ensure `find_linked_issue_by_ref` returns an Issue of epic type when passed the Issue key
+    '''
+    # Add an Epic fixture to the Jira dict
+    mock_jira['TEST-1'] = issue = Issue.deserialize(EPIC_1, project)
+
+    with mock.patch('jira_offline.edit.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
+        linked_issue = find_linked_issue_by_ref('TEST-1')
+
+    compare_issue_helper(issue, linked_issue)
+
+
+@pytest.mark.parametrize('search_str', [
+    ('This is an epic'),
+    ('is an epic'),
+])
+def test_create__find_linked_issue_by_ref__match_by_summary(mock_jira, project, search_str):
+    '''
+    Ensure `find_linked_issue_by_ref` returns an Issue of epic type when passed a summary
+    '''
+    # Add an Epic fixture to the Jira dict
+    mock_jira['TEST-1'] = issue = Issue.deserialize(EPIC_1, project)
+
+    with mock.patch('jira_offline.edit.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
+        linked_issue = find_linked_issue_by_ref(search_str)
+
+    compare_issue_helper(issue, linked_issue)
+
+
+def test_create__find_linked_issue_by_ref__match_by_epic_name(mock_jira, project):
+    '''
+    Ensure `find_linked_issue_by_ref` returns an Issue of epic type when passed an epic_name
+    '''
+    # Add an Epic fixture to the Jira dict
+    mock_jira['TEST-1'] = issue = Issue.deserialize(EPIC_1, project)
+
+    with mock.patch('jira_offline.edit.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
+        linked_issue = find_linked_issue_by_ref('0.1: Epic about a thing')
+
+    compare_issue_helper(issue, linked_issue)
+
+
+def test_create__find_linked_issue_by_ref__raise_on_failed_to_match(mock_jira, project):
+    '''
+    Ensure exception raised when epic not found
+    '''
+    with mock.patch('jira_offline.edit.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
+        with pytest.raises(EpicNotFound):
+            find_linked_issue_by_ref('fake epic reference')
+
+
+def test_create__find_linked_issue_by_ref__raise_on_duplicate_ref_string(mock_jira, project):
+    '''
+    Ensure exception raised when there are two epics matching the search string
+    '''
+    # Setup two epic fixtures
+    mock_jira['TEST-1'] = Issue.deserialize(EPIC_1, project)
+
+    with mock.patch.dict(EPIC_1, {'key': 'TEST-2'}):
+        mock_jira['TEST-2'] = Issue.deserialize(EPIC_1, project)
+
+    with mock.patch('jira_offline.edit.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
+        with pytest.raises(EpicSearchStrUsedMoreThanOnce):
+            find_linked_issue_by_ref('This is an epic')
+
+
+def test_create__patch_issue_from_dict__set_string_to_value(mock_jira, project):
+    '''
+    Ensure an Issue can have attributes set to a string
+    '''
+    issue = Issue.deserialize(ISSUE_1, project)
+
+    issue.commit = mock.Mock()
+
+    with mock.patch('jira_offline.jira.jira', mock_jira):
+        patched = patch_issue_from_dict(issue, {'assignee': 'eggs'})
+
+    assert issue.assignee == 'eggs'
+    assert issue.commit.called
+    assert patched is True
+
+
+def test_create__patch_issue_from_dict__set_string_to_blank(mock_jira, project):
+    '''
+    Ensure an Issue can have attributes set to an empty string and it will result in None
+    '''
+    issue = Issue.deserialize(ISSUE_1, project)
+
+    issue.commit = mock.Mock()
+
+    with mock.patch('jira_offline.jira.jira', mock_jira):
+        patched = patch_issue_from_dict(issue, {'assignee': ''})
+
+    assert issue.assignee is None
+    assert issue.commit.called
+    assert patched is True
+
+
+def test_create__patch_issue_from_dict__set_priority(mock_jira, project):
+    '''
+    Ensure an Issue.priority can be set
+    '''
+    issue = Issue.deserialize(ISSUE_1, project)
+
+    issue.commit = mock.Mock()
+
+    with mock.patch('jira_offline.jira.jira', mock_jira):
+        patched = patch_issue_from_dict(issue, {'priority': 'Bacon'})
+
+    assert issue.priority == 'Bacon'
+    assert issue.commit.called
+    assert patched is True
+
+
+def test_create__patch_issue_from_dict__skips_readonly_fields(mock_jira, project):
+    '''
+    Ensure readonly fields are skipped during a patch
+    '''
+    issue = Issue.deserialize(ISSUE_1, project)
+
+    issue.commit = mock.Mock()
+
+    assert issue.summary == 'This is the story summary'
+    assert issue.project_id == '99fd9182cfc4c701a8a662f6293f4136201791b4'
+
+    with mock.patch('jira_offline.jira.jira', mock_jira):
+        patched = patch_issue_from_dict(issue, {'key': 'TEST-71', 'project_id': 'Bacon', 'summary': 'Egg'})
+
+    # Assert writeable field is modified, but the readonly value is not modified
+    assert issue.summary == 'Egg'
+    assert issue.project_id == '99fd9182cfc4c701a8a662f6293f4136201791b4'
+    assert issue.commit.called
+    assert patched is True
+
+
+@pytest.mark.parametrize('param', [
+    ('bacon'),
+    ('egg,bacon'),
+])
+def test_create__patch_issue_from_dict__set_set(mock_jira, project, param):
+    '''
+    When patching a set, if a set is passed overwrite existing value, if a str is passed append to
+    the existing set
+    '''
+    with mock.patch.dict(ISSUE_1, {'labels': set(['egg'])}):
+        issue = Issue.deserialize(ISSUE_1, project)
+
+    issue.commit = mock.Mock()
+
+    assert issue.labels == {'egg'}
+
+    with mock.patch('jira_offline.jira.jira', mock_jira):
+        patched = patch_issue_from_dict(issue, {'labels': param})
+
+    assert issue.labels == {'egg', 'bacon'}
+    assert issue.commit.called
+    assert patched is True
+
+
+@pytest.mark.parametrize('param', [
+    ('bacon'),
+    ('egg,bacon'),
+])
+def test_create__patch_issue_from_dict__remove_from_set(mock_jira, project, param):
+    '''
+    Ensure patch will remove one or many from a set
+    '''
+    with mock.patch.dict(ISSUE_1, {'labels': set(param.split(','))}):
+        issue = Issue.deserialize(ISSUE_1, project)
+
+    issue.commit = mock.Mock()
+
+    assert issue.labels == set(param.split(','))
+
+    with mock.patch('jira_offline.jira.jira', mock_jira):
+        patched = patch_issue_from_dict(issue, {'remove_labels': param})
+
+    assert issue.labels == set()
+    assert issue.commit.called
+    assert patched is True
+
+
+@pytest.mark.skip(reason='Will succeed when there is a list-type field on Issue class')
+@pytest.mark.parametrize('param', [
+    ('bacon'),
+    ('egg,bacon'),
+])
+def test_create__patch_issue_from_dict__set_list(mock_jira, project, param):
+    '''
+    When patching a list, if a list is passed, overwrite existing value, if a str is passed append to
+    the existing list
+    '''
+    with mock.patch.dict(ISSUE_1, {'labels': ['egg']}):
+        issue = Issue.deserialize(ISSUE_1, project)
+
+    issue.commit = mock.Mock()
+
+    assert issue.labels == ['egg']
+
+    with mock.patch('jira_offline.jira.jira', mock_jira):
+        patched = patch_issue_from_dict(issue, {'labels': param})
+
+    assert issue.labels == ['egg', 'bacon']
+    assert issue.commit.called
+    assert patched is True
+
+
+@pytest.mark.skip(reason='Will succeed when there is a list-type field on Issue class')
+@pytest.mark.parametrize('param', [
+    ('bacon'),
+    ('egg,bacon'),
+])
+def test_create__patch_issue_from_dict__remove_from_list(mock_jira, project, param):
+    '''
+    Ensure patch will remove one or many from a list
+    '''
+    with mock.patch.dict(ISSUE_1, {'labels': param.split(',')}):
+        issue = Issue.deserialize(ISSUE_1, project)
+
+    issue.commit = mock.Mock()
+
+    assert issue.labels == param.split(',')
+
+    with mock.patch('jira_offline.jira.jira', mock_jira):
+        patched = patch_issue_from_dict(issue, {'remove_labels': param})
+
+    assert issue.labels == []
+    assert issue.commit.called
+    assert patched is True
+
+
+@pytest.mark.parametrize('customfield_name', [
+    ('arbitrary-user-defined-field'),
+    ('extended.arbitrary-user-defined-field'),
+])
+def test_create__patch_issue_from_dict__set_extended_customfield(mock_jira, customfield_name):
+    '''
+    Ensure user-defined customfield "arbitrary-user-defined-field" can be set
+    '''
+    customfields = CustomFields(
+        extended={'arbitrary-user-defined-field': 'customfield_10111'}
+    )
+    project = ProjectMeta(key='TEST', customfields=customfields)
+
+    issue = Issue.deserialize(ISSUE_1, project)
+
+    issue.commit = mock.Mock()
+
+    with mock.patch('jira_offline.jira.jira', mock_jira):
+        patched = patch_issue_from_dict(issue, {customfield_name: 'eggs'})
+
+    assert issue.extended['arbitrary-user-defined-field'] == 'eggs'
+    assert issue.commit.called
+    assert patched is True
+
+
+def test_create__patch_issue_from_dict__ignore_undefined_customfield(mock_jira):
+    '''
+    Ensure arbitrary k:v mappings passed into `patch_issue_from_dict` are only applied as extended
+    customfields if they are user-defined in config.
+    '''
+    customfields = CustomFields(
+        extended={}
+    )
+    project = ProjectMeta(key='TEST', customfields=customfields)
+
+    issue = Issue.deserialize(ISSUE_1, project)
+
+    issue.commit = mock.Mock()
+
+    with mock.patch('jira_offline.jira.jira', mock_jira):
+        patched = patch_issue_from_dict(issue, {'arbitrary-user-defined-field': 'eggs'})
+
+    assert issue.extended == {}
+    assert not issue.commit.called
+    assert patched is False
+
+
+def test_create__patch_issue_from_dict__uses_reset_before_edit(mock_jira):
+    '''
+    Ensure that the reset_before_edit metadata field causes a single-field reset before a patch
+    '''
+    project = ProjectMeta(
+        key='TEST',
+        customfields=CustomFields(sprint='customfield_10300'),
+        sprints={
+            1: Sprint(id=1, name='Sprint 1', active=True),
+            2: Sprint(id=2, name='Sprint 2', active=False),
+            3: Sprint(id=3, name='Sprint 3', active=False),
+        },
+    )
+
+    # Create an issue which already exists in a sprint
+    with mock.patch.dict(ISSUE_1, {'sprint': 'Sprint 1'}):
+        issue = Issue.deserialize(ISSUE_1, project)
+
+    issue.commit = mock.Mock()
+
+    # Add the issue to another sprint
+    issue.sprint.add(Sprint(id=2, name='Sprint 2', active=False))
+
+    assert issue.sprint == {
+        Sprint(id=1, name='Sprint 1', active=True),
+        Sprint(id=2, name='Sprint 2', active=False),
+    }
+
+    with mock.patch('jira_offline.jira.jira', mock_jira):
+        patched = patch_issue_from_dict(issue, {'sprint': 'Sprint 3'})
+
+    # Ensure the modification of sprint before the patch is reset, leaving just sprint 1 & 3 on the issue
+    assert issue.sprint == {
+        Sprint(id=1, name='Sprint 1', active=True),
+        Sprint(id=3, name='Sprint 3', active=False),
+    }
+    assert issue.commit.called
+    assert patched is True
+
+
+def test_create__patch_issue_from_dict__epic_name_ignored_on_story_issuetype(mock_jira, project):
+    '''
+    Ensure the field Issue.epic_name is only imported which issuetype==Epic
+    '''
+    issue = Issue.deserialize(ISSUE_1, project)
+
+    issue.commit = mock.Mock()
+
+    with mock.patch('jira_offline.jira.jira', mock_jira):
+        patched = patch_issue_from_dict(issue, {'epic_name': 'eggs'})
+
+    assert issue.epic_name is None
+    assert not issue.commit.called
+    assert patched is False
+
+
+def test_create__patch_issue_from_dict__epic_name_patched_on_epic_issuetype(mock_jira, project):
+    '''
+    Ensure the field Issue.epic_name is only imported which issuetype==Epic
+    '''
+    issue = Issue.deserialize(EPIC_1, project)
+
+    issue.commit = mock.Mock()
+
+    with mock.patch('jira_offline.jira.jira', mock_jira):
+        patched = patch_issue_from_dict(issue, {'epic_name': 'eggs'})
+
+    assert issue.epic_name == 'eggs'
+    assert issue.commit.called
+    assert patched is True
+
+
+def test_create__patch_issue_from_dict__ignores_unused_customfields(mock_jira):
+    '''
+    Ensure the customfields on the Issue object are not set when the customfield IS NOT configured
+    for the project
+    '''
+    project = ProjectMeta(
+        key='TEST',
+        customfields=CustomFields(epic_name='customfield_10100')
+    )
+    with mock.patch.dict(EPIC_1, {'epic_name': None}):
+        issue = Issue.deserialize(EPIC_1, project)
+
+    issue.commit = mock.Mock()
+
+    with mock.patch('jira_offline.jira.jira', mock_jira):
+        patched = patch_issue_from_dict(issue, {'epic_name': 'eggs'})
+
+    assert issue.epic_name == 'eggs'
+    assert issue.commit.called
+    assert patched is True
+
+
+def test_create__patch_issue_from_dict__doesnt_ignore_not_unused_customfields(mock_jira):
+    '''
+    Ensure the customfields on the Issue object are set when the customfield IS configured for the
+    project
+    '''
+    project = ProjectMeta(
+        key='TEST',
+        customfields=CustomFields()
+    )
+    with mock.patch.dict(EPIC_1, {'epic_name': None}):
+        issue = Issue.deserialize(EPIC_1, project)
+
+    issue.commit = mock.Mock()
+
+    with mock.patch('jira_offline.jira.jira', mock_jira):
+        patched = patch_issue_from_dict(issue, {'epic_name': 'eggs'})
+
+    assert issue.epic_name is None
+    assert not issue.commit.called
+    assert patched is False
+
+
+@pytest.mark.parametrize('field', [
+    ('epic_link'),
+    ('parent_link'),
+])
+@mock.patch('jira_offline.edit.find_linked_issue_by_ref')
+def test_create__patch_issue_from_dict__links_issue(mock_find_linked_issue_by_ref, mock_jira, field):
+    '''
+    Ensure the fields Issue.epic_link and Issue.parent_link are set correctly
+    '''
+    project = ProjectMeta(
+        'TEST',
+        customfields=CustomFields(
+            epic_link='customfield_10100',
+            parent_link='customfield_10100'
+        ),
+    )
+    issue = Issue.deserialize(ISSUE_1, project)
+
+    issue.commit = mock.Mock()
+
+    mock_find_linked_issue_by_ref.return_value = linked = Issue.deserialize(EPIC_1, project)
+
+    with mock.patch('jira_offline.jira.jira', mock_jira):
+        patched = patch_issue_from_dict(issue, {field: 'eggs'})
+
+    mock_find_linked_issue_by_ref.assert_called_with('eggs')
+    assert getattr(issue, field) == linked.key
+    assert issue.commit.called
+    assert patched is True
+
+
+def test_create__patch_issue_from_dict__idempotent(mock_jira, project):
+    '''
+    Ensure an issue can be patched twice and produces an identical diff
+    '''
+    issue = Issue.deserialize(ISSUE_1, project)
+
+    issue.commit = mock.Mock()
+
+    # import same test JSON twice
+    with mock.patch('jira_offline.jira.jira', mock_jira):
+        patched = patch_issue_from_dict(issue, {'key': 'TEST-71', 'assignee': 'hoganp'})
+
+    assert issue.assignee == 'hoganp'
+    assert issue.diff() == [('change', 'assignee', ('hoganp', 'danil1'))]
+    assert issue.commit.called
+    assert patched is True
+
+    with mock.patch('jira_offline.jira.jira', mock_jira):
+        patched = patch_issue_from_dict(issue, {'key': 'TEST-71', 'assignee': 'hoganp'})
+
+    assert issue.assignee == 'hoganp'
+    assert issue.diff() == [('change', 'assignee', ('hoganp', 'danil1'))]
+    assert issue.commit.called
+    assert patched is True
+
+
+def test_create__patch_issue_from_dict__raises_exception_when_passed_an_unknown_epic_link(mock_jira, project):
+    '''
+    Ensure an exception is raised in strict mode, when an epic_link is passed which does not match
+    an existing epic
+    '''
+    issue = Issue.deserialize(EPIC_1, project)
+
+    issue.commit = mock.Mock()
+
+    with mock.patch('jira_offline.edit.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
+        with pytest.raises(EpicNotFound):
+            patch_issue_from_dict(issue, {'epic_link': 'Nothing'}, strict=True)
+
+
+def test_create__patch_issue_from_dict__DOES_NOT_raise_exception_when_passed_a_known_epic_link(mock_jira, project):
+    '''
+    Ensure NO exception is raised in strict mode, when an epic_link is passed which does not match
+    an existing epic
+    '''
+    issue = Issue.deserialize(EPIC_1, project)
+
+    issue.commit = mock.Mock()
+
+    with mock.patch('jira_offline.edit.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
+        patched = patch_issue_from_dict(issue, {'epic_link': 'Nothing'})
+
+    assert patched is True

--- a/test/test_jira_class.py
+++ b/test/test_jira_class.py
@@ -1127,10 +1127,15 @@ def test_jira__keys__respect_the_filter(mock_jira_core):
     '''
     Ensure that jira.keys() respects a filter set in jira.filter
     '''
-    issue_1 = Issue.deserialize(ISSUE_1, project=ProjectMeta('FIRST'))
+    # Setup the project configuration with two projects
+    project_1 = ProjectMeta('FIRST')
+    project_2 = ProjectMeta('SECOND')
+    mock_jira_core.config.projects = {project_1.id: project_1, project_2.id: project_2}
+
+    issue_1 = Issue.deserialize(ISSUE_1, project=project_1)
 
     with mock.patch.dict(ISSUE_1, {'key': 'TEST-72'}):
-        issue_2 = Issue.deserialize(ISSUE_1, project=ProjectMeta('SECOND'))
+        issue_2 = Issue.deserialize(ISSUE_1, project=project_2)
 
     # Setup the Jira DataFrame
     with mock.patch('jira_offline.jira.jira', mock_jira_core):
@@ -1149,10 +1154,15 @@ def test_jira__values__respect_the_filter(mock_jira_core):
     '''
     Ensure that jira.values() respects a filter set in jira.filter
     '''
-    issue_1 = Issue.deserialize(ISSUE_1, project=ProjectMeta('FIRST'))
+    # Setup the project configuration with two projects
+    project_1 = ProjectMeta('FIRST')
+    project_2 = ProjectMeta('SECOND')
+    mock_jira_core.config.projects = {project_1.id: project_1, project_2.id: project_2}
+
+    issue_1 = Issue.deserialize(ISSUE_1, project=project_1)
 
     with mock.patch.dict(ISSUE_1, {'key': 'TEST-72'}):
-        issue_2 = Issue.deserialize(ISSUE_1, project=ProjectMeta('SECOND'))
+        issue_2 = Issue.deserialize(ISSUE_1, project=project_2)
 
     # Setup the Jira DataFrame
     with mock.patch('jira_offline.jira.jira', mock_jira_core):
@@ -1171,10 +1181,15 @@ def test_jira__items__respect_the_filter(mock_jira_core):
     '''
     Ensure that jira.items() respects a filter set in jira.filter
     '''
-    issue_1 = Issue.deserialize(ISSUE_1, project=ProjectMeta('FIRST'))
+    # Setup the project configuration with two projects
+    project_1 = ProjectMeta('FIRST')
+    project_2 = ProjectMeta('SECOND')
+    mock_jira_core.config.projects = {project_1.id: project_1, project_2.id: project_2}
+
+    issue_1 = Issue.deserialize(ISSUE_1, project=project_1)
 
     with mock.patch.dict(ISSUE_1, {'key': 'TEST-72'}):
-        issue_2 = Issue.deserialize(ISSUE_1, project=ProjectMeta('SECOND'))
+        issue_2 = Issue.deserialize(ISSUE_1, project=project_2)
 
     # Setup the Jira DataFrame
     with mock.patch('jira_offline.jira.jira', mock_jira_core):

--- a/test/test_sql_filter.py
+++ b/test/test_sql_filter.py
@@ -201,11 +201,13 @@ def test_parse__primitive_list__set(mock_jira, project, operator, search_terms, 
     ('in', '"Story Done", Egg', 2),
     ('in', 'Egg', 1),
     ('in', '"Story Done"', 1),
+    ('in', 'Egg, Missing', 1),
     ('in', 'Missing', 0),
 
     ('not in', '"Story Done", Egg', 0),
     ('not in', 'Egg', 1),
     ('not in', '"Story Done"', 1),
+    ('not in', 'Egg, Missing', 1),
     ('not in', 'Missing', 2),
 ])
 def test_parse__primitive_list__string(mock_jira, project, operator, search_terms, count):

--- a/test/utils/serializer/test_list.py
+++ b/test/utils/serializer/test_list.py
@@ -21,6 +21,16 @@ def test_list_deserialize_from_list():
     assert isinstance(obj.l, list)
     assert obj.l == ['abc', 'def']
 
+def test_list_deserialize_from_commaseparated():
+    """
+    Test list deserializes from comma-separated string
+    """
+    obj = Test.deserialize({
+        'l': 'abc,def'
+    })
+    assert isinstance(obj.l, list)
+    assert obj.l == ['abc', 'def']
+
 def test_list_deserialize_roundrip():
     """
     Test list deserializes/serializes in a loss-less roundrip
@@ -65,4 +75,4 @@ def test_list_bad_deserialize():
     Test bad list deserialize raises exception
     '''
     with pytest.raises(DeserializeError):
-        Test.deserialize({'l': 'Egx'})
+        Test.deserialize({'l': {'Egg'}})

--- a/test/utils/serializer/test_set.py
+++ b/test/utils/serializer/test_set.py
@@ -31,6 +31,16 @@ def test_set_deserialize_from_set():
     assert isinstance(obj.s, set)
     assert obj.s == {'1', '2', '3'}
 
+def test_set_deserialize_from_commaseparated():
+    """
+    Test list deserializes from comma-separated string
+    """
+    obj = Test.deserialize({
+        's': '1,2,3'
+    })
+    assert isinstance(obj.s, set)
+    assert obj.s == {'1', '2', '3'}
+
 def test_set_deserialize_roundtrip():
     """
     Test set deserializes/serializes in a loss-less roundtrip
@@ -73,4 +83,4 @@ def test_set_bad_deserialize():
     Test bad set deserialize raises exception (exception raised when passed value is not a list)
     '''
     with pytest.raises(DeserializeError):
-        Test.deserialize({'s': 'Egx'})
+        Test.deserialize({'l': {'Egg'}})

--- a/test/utils/test_cli.py
+++ b/test/utils/test_cli.py
@@ -5,7 +5,6 @@ import pytest
 
 from conftest import not_raises
 from fixtures import ISSUE_1
-from jira_offline.exceptions import BadParamsPassedToValidCustomfield
 from jira_offline.jira import Issue
 from jira_offline.utils.cli import CustomfieldsAsOptions, prepare_df, ValidCustomfield
 
@@ -112,25 +111,6 @@ def test_validcustomfield_calls__get_project_when_projectkey_supplied(mock_valid
     assert not mock_jira.load_issues.called
     assert not mock_validcustomfield_get_issue.called
     assert mock_validcustomfield_get_project.called
-
-
-def test_validcustomfield__raises_error_on_neither_key_nor_projectkey_supplied(mock_jira):
-    '''
-    Ensure `ValidCustomfield.handle_parse_result` raises when neither `Issue.key` or `ProjectMeta.key`
-    are supplied
-    '''
-    # CLI options
-    opts = {}
-
-    command = CustomfieldsAsOptions(*tuple(), **{'name': 'new', 'params': []})
-
-    with mock.patch('jira_offline.utils.cli.jira', mock_jira):
-        with pytest.raises(BadParamsPassedToValidCustomfield):
-            ValidCustomfield(
-                ['--arbitrary-user-defined-field'], help=''
-            ).handle_parse_result(
-                click.core.Context(command), opts, None
-            )
 
 
 def test_validcustomfield__raises_error_on_customfield_supplied_but_not_mapped_to_project(mock_jira):

--- a/test/utils/test_convert.py
+++ b/test/utils/test_convert.py
@@ -7,7 +7,7 @@ from unittest import mock
 import pytest
 
 from fixtures import ISSUE_1, ISSUE_NEW, JIRAAPI_OBJECT
-from jira_offline.create import patch_issue_from_dict
+from jira_offline.edit import patch_issue_from_dict
 from jira_offline.models import CustomFields, Issue, ProjectMeta, Sprint
 from jira_offline.utils.convert import issue_to_jiraapi_update, jiraapi_object_to_issue, parse_sprint
 

--- a/test/utils/test_convert.py
+++ b/test/utils/test_convert.py
@@ -220,7 +220,9 @@ def test_issue_to_jiraapi_update__outputs_sprint_as_string(mock_jira):
 
     # Create an issue fixture and add it to a sprint
     issue = Issue.deserialize(ISSUE_1, project)
-    patch_issue_from_dict(issue, {'sprint': 'Sprint 1'})
+
+    with mock.patch('jira_offline.jira.jira', mock_jira):
+        patch_issue_from_dict(issue, {'sprint': 'Sprint 1'})
 
     issue_dict = issue_to_jiraapi_update(issue, {'sprint'})
 
@@ -246,7 +248,9 @@ def test_issue_to_jiraapi_update__handles_sprint_on_new_issues(mock_jira):
 
     # Create an issue fixture and add it to a sprint
     issue = Issue.deserialize(ISSUE_1, project)
-    patch_issue_from_dict(issue, {'sprint': 'Sprint 1'})
+
+    with mock.patch('jira_offline.jira.jira', mock_jira):
+        patch_issue_from_dict(issue, {'sprint': 'Sprint 1'})
 
     issue_dict = issue_to_jiraapi_update(issue, {'sprint'})
 
@@ -278,7 +282,8 @@ def test_issue_to_jiraapi_update__outputs_only_sprint_diff(mock_jira, issue_fixt
     # Create an issue which already exists in a sprint, and then add it to another sprint
     with mock.patch.dict(issue_fixture, {'sprint': 'Sprint 1'}):
         issue = Issue.deserialize(issue_fixture, project)
-        issue.commit = mock.Mock()
+
+    with mock.patch('jira_offline.jira.jira', mock_jira):
         patch_issue_from_dict(issue, {'sprint': 'Sprint 2'})
 
     issue_dict = issue_to_jiraapi_update(issue, {'sprint'})
@@ -311,8 +316,9 @@ def test_issue_to_jiraapi_update__outputs_only_sprint_diff_2(mock_jira, issue_fi
 
     # Create an issue without a sprint, and add it to a sprint
     issue = Issue.deserialize(issue_fixture, project)
-    issue.commit = mock.Mock()
-    patch_issue_from_dict(issue, {'sprint': 'Sprint 2'})
+
+    with mock.patch('jira_offline.jira.jira', mock_jira):
+        patch_issue_from_dict(issue, {'sprint': 'Sprint 2'})
 
     issue_dict = issue_to_jiraapi_update(issue, {'sprint'})
 

--- a/test/utils/test_convert.py
+++ b/test/utils/test_convert.py
@@ -204,7 +204,7 @@ def test_issue_to_jiraapi_update__customfields_and_extended_customfields_returne
     }
 
 
-def test_issue_to_jiraapi_update__outputs_sprint_as_string(mock_jira, project):
+def test_issue_to_jiraapi_update__outputs_sprint_as_string(mock_jira):
     '''
     Ensure issue_to_jiraapi_update converts the sprint set into a string
     '''
@@ -220,7 +220,7 @@ def test_issue_to_jiraapi_update__outputs_sprint_as_string(mock_jira, project):
 
     # Create an issue fixture and add it to a sprint
     issue = Issue.deserialize(ISSUE_1, project)
-    issue.sprint = {Sprint(id=1, name='Sprint 1', active=True)}
+    patch_issue_from_dict(issue, {'sprint': 'Sprint 1'})
 
     issue_dict = issue_to_jiraapi_update(issue, {'sprint'})
 
@@ -230,7 +230,7 @@ def test_issue_to_jiraapi_update__outputs_sprint_as_string(mock_jira, project):
     }
 
 
-def test_issue_to_jiraapi_update__handles_sprint_on_new_issues(mock_jira, project):
+def test_issue_to_jiraapi_update__handles_sprint_on_new_issues(mock_jira):
     '''
     Ensure issue_to_jiraapi_update handles sprint field on new issues
     '''
@@ -246,7 +246,7 @@ def test_issue_to_jiraapi_update__handles_sprint_on_new_issues(mock_jira, projec
 
     # Create an issue fixture and add it to a sprint
     issue = Issue.deserialize(ISSUE_1, project)
-    issue.sprint = {Sprint(id=1, name='Sprint 1', active=True)}
+    patch_issue_from_dict(issue, {'sprint': 'Sprint 1'})
 
     issue_dict = issue_to_jiraapi_update(issue, {'sprint'})
 
@@ -260,7 +260,7 @@ def test_issue_to_jiraapi_update__handles_sprint_on_new_issues(mock_jira, projec
     ISSUE_1,
     ISSUE_NEW,
 ])
-def test_issue_to_jiraapi_update__outputs_only_sprint_diff(mock_jira, project, issue_fixture):
+def test_issue_to_jiraapi_update__outputs_only_sprint_diff(mock_jira, issue_fixture):
     '''
     Ensure issue_to_jiraapi_update outputs only the new item in a sprint set
     '''
@@ -276,7 +276,7 @@ def test_issue_to_jiraapi_update__outputs_only_sprint_diff(mock_jira, project, i
     )
 
     # Create an issue which already exists in a sprint, and then add it to another sprint
-    with mock.patch.dict(issue_fixture, {'sprint': [{'id': 1, 'name': 'Sprint 1', 'active': True}]}):
+    with mock.patch.dict(issue_fixture, {'sprint': 'Sprint 1'}):
         issue = Issue.deserialize(issue_fixture, project)
         issue.commit = mock.Mock()
         patch_issue_from_dict(issue, {'sprint': 'Sprint 2'})
@@ -294,7 +294,7 @@ def test_issue_to_jiraapi_update__outputs_only_sprint_diff(mock_jira, project, i
     ISSUE_1,
     ISSUE_NEW,
 ])
-def test_issue_to_jiraapi_update__outputs_only_sprint_diff_2(mock_jira, project, issue_fixture):
+def test_issue_to_jiraapi_update__outputs_only_sprint_diff_2(mock_jira, issue_fixture):
     '''
     Ensure issue_to_jiraapi_update outputs only the new item in a sprint set
     '''


### PR DESCRIPTION
* Got rid of that code smell `Issue.metadata['parse_func']` stuff by refactoring into the serializer
* Add ability to remove (delete) fields from issues via dynamic flags on the `jira edit` command.
* Fixed support for the `Issue.sprint` field in SQL `--filter` strings
* Also tacked on the use of `--filter` to enable editing multiple issues at once

Refs #128 #87 